### PR TITLE
feat(phase6): HTTP fetch shim + Net::HTTP + fix Phase 3 D1/KV $raise typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ opposite bet: no DSL, real Sinatra, real Rack, real middleware chain.
   - [bin/compile-erb + views/ — build-time ERB precompiler](#bincompile-erb--views--build-time-erb-precompiler)
 - [Build & run](#build--run)
 - [Directory layout](#directory-layout)
+- [Net::HTTP works (Phase 6)](#nethttp-works-phase-6)
 - [Project status & phases](#project-status--phases)
 - [Strict no-fallback policy](#strict-no-fallback-policy)
 - [License](#license)
@@ -466,6 +467,48 @@ rg "homurabi patch" vendor lib
 
 ---
 
+## Net::HTTP works (Phase 6)
+
+The Phase 6 patch added `Cloudflare::HTTP.fetch` (a thin Ruby wrapper
+around `globalThis.fetch`) and a `Net::HTTP` shim that delegates to it.
+Existing Ruby code that uses `Net::HTTP.get(URI('...'))` works
+unchanged inside Sinatra routes — the only addition required is the
+`.__await__` suffix that already appears around D1/KV/R2 calls.
+
+```ruby
+get '/demo/http' do
+  content_type 'application/json'
+  res = Net::HTTP.get_response(URI('https://api.ipify.org/?format=json')).__await__
+  {
+    'status'       => res.code,
+    'content_type' => res['content-type'],
+    'body'         => JSON.parse(res.body)
+  }.to_json
+end
+```
+
+What's covered:
+
+- `Cloudflare::HTTP.fetch(url, method:, headers:, body:)` →
+  `Cloudflare::HTTPResponse` with `status` / `headers` (lowercased
+  Hash) / `body` (String) / `json` / `ok?` / `[]`.
+- `Net::HTTP.get(uri)` → body String.
+- `Net::HTTP.get_response(uri)` → `Net::HTTPResponse` with `body`
+  / `code` / `message` / `[]` / `each_header`.
+- `Net::HTTP.post_form(uri, hash)` → urlencoded POST returning
+  `Net::HTTPResponse`.
+- `Kernel#URI('https://...')` shorthand for `URI.parse(...)`.
+
+What's *not* covered (raw TCP is impossible on Workers): persistent
+connections, `Net::HTTP.start`-style block forms, request objects, raw
+socket access, multipart upload, chunked streaming bodies. Use
+`Cloudflare::HTTP.fetch` directly for those — it accepts arbitrary
+fetch `init` options through `headers:` / `method:` / `body:`.
+
+Smoke tests live in `test/http_smoke.rb` and run as part of `npm test`.
+
+---
+
 ## Project status & phases
 
 The project follows a strict four-phase plan (see
@@ -479,6 +522,7 @@ of each phase:
 | **Phase 2** | Real `janbiedermann/sinatra` compiled and served through the Rack handler, full middleware chain (Rack::Protection headers), production `curl` returning actual Sinatra bodies, no ERB-in-dev-mode workarounds, no `request.body.read` stub. | ✅ shipped at commits `d74c329` / `e6d5f66` / `93fba66` — and the 5 1st-pass compromises (body stub, APP_ENV force, force_encoding no-op, Sinatra-side `next` patch, grep-ability) were all closed in a subsequent pass. |
 | **Phase 3** | D1 / KV / R2 bindings callable from real Sinatra routes on Workers. | ✅ shipped at commits `ba0a772` / `4210de5`. All nine CRUD routes verified on production. |
 | **Phase 4** | Evidence collection + マスター + Codex double review. | In progress. |
+| **Phase 6** | HTTP client foundation — `Cloudflare::HTTP.fetch` wrapping `globalThis.fetch`, plus a `Net::HTTP` shim (`get` / `get_response` / `post_form`) and `Kernel#URI` so unmodified Ruby HTTP code can reach the network through the Workers `fetch` API. | ✅ shipped on `feature/phase6-fetch`. 14 new smoke tests pass; demos at `/demo/http` and `/demo/http/raw` hit the public ipify API. |
 
 ### Definition of Done (from PLAN.md §1.1)
 

--- a/app/hello.rb
+++ b/app/hello.rb
@@ -14,6 +14,7 @@
 
 require 'json'
 require 'sinatra/base'
+require 'net/http'
 
 class App < Sinatra::Base
   # --- Cloudflare binding helpers ------------------------------------
@@ -186,6 +187,36 @@ class App < Sinatra::Base
     key    = params['key']
     bucket.delete(key).__await__
     { 'key' => key, 'deleted' => true }.to_json
+  end
+
+  # ------------------------------------------------------------------
+  # Phase 6 demo — Net::HTTP shim through globalThis.fetch.
+  # GET /demo/http hits the public ipify API and echoes back the JSON
+  # the way any other Net::HTTP-based Ruby gem would see it.
+  # ------------------------------------------------------------------
+  get '/demo/http' do
+    content_type 'application/json'
+    res = Net::HTTP.get_response(URI('https://api.ipify.org/?format=json')).__await__
+    {
+      'demo'    => 'Net::HTTP through Cloudflare fetch',
+      'status'  => res.code,
+      'message' => res.message,
+      'content_type' => res['content-type'],
+      'body'    => JSON.parse(res.body)
+    }.to_json
+  end
+
+  # Same demo using the lower-level Cloudflare::HTTP.fetch directly.
+  get '/demo/http/raw' do
+    content_type 'application/json'
+    res = Cloudflare::HTTP.fetch('https://api.ipify.org/?format=json').__await__
+    {
+      'demo'    => 'Cloudflare::HTTP.fetch (raw)',
+      'status'  => res.status,
+      'ok'      => res.ok?,
+      'headers' => { 'content-type' => res['content-type'] },
+      'json'    => res.json
+    }.to_json
   end
 end
 

--- a/bin/init-local-d1
+++ b/bin/init-local-d1
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Initialize the LOCAL Wrangler D1 database with the schema in
+# bin/schema.sql so `wrangler dev --local` returns real rows from
+# routes like / and /d1/users instead of throwing D1Error.
+#
+# - Local Wrangler SQLite only (--local flag is enforced below).
+# - Idempotent: existing rows are preserved (CREATE TABLE IF NOT EXISTS,
+#   INSERT OR IGNORE).
+# - The remote production D1 database is never touched by this script.
+# - Not invoked automatically by build / dev / deploy — run manually.
+#
+# Usage:
+#   ./bin/init-local-d1
+#   npm run d1:init
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+DB_NAME="homurabi-db"
+SCHEMA_FILE="bin/schema.sql"
+
+if [[ ! -f "$SCHEMA_FILE" ]]; then
+  echo "ERROR: $SCHEMA_FILE not found" >&2
+  exit 1
+fi
+
+echo "→ Applying $SCHEMA_FILE to local D1 database '$DB_NAME'..."
+npx wrangler d1 execute "$DB_NAME" --local --file "$SCHEMA_FILE"
+
+echo
+echo "✓ Local D1 ready. Try:"
+echo "    npx wrangler dev --local"
+echo "    curl http://127.0.0.1:8787/d1/users | jq ."

--- a/bin/schema.sql
+++ b/bin/schema.sql
@@ -1,0 +1,23 @@
+-- homurabi D1 schema (LOCAL DEVELOPMENT ONLY)
+--
+-- Mirrors the structure used by app/hello.rb routes. Idempotent —
+-- safe to re-run; existing rows are preserved.
+--
+-- Usage (local Wrangler SQLite only):
+--   npm run d1:init          (or:  bin/init-local-d1)
+--
+-- This file is NOT intended to be applied to the remote production
+-- D1 database. Production schema/seed is managed manually by the
+-- repository owner. Do not run with `--remote` unless you know what
+-- you are doing.
+
+CREATE TABLE IF NOT EXISTS users (
+  id   INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT    NOT NULL
+);
+
+INSERT OR IGNORE INTO users (id, name) VALUES
+  (1, 'Kazu'),
+  (2, 'Homurabi-chan'),
+  (3, 'Sinatra'),
+  (4, 'Opal');

--- a/lib/cloudflare_workers.rb
+++ b/lib/cloudflare_workers.rb
@@ -506,7 +506,7 @@ module Cloudflare
       js_stmt = @js
       cf = Cloudflare
       err_cls = Cloudflare::D1Error
-      `#{js_stmt}.all().then(function(res) { return #{cf}.$js_rows_to_ruby(res.results); }).catch(function(e) { #{Kernel}.$$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'D1', operation: 'all'}))); })`
+      `#{js_stmt}.all().then(function(res) { return #{cf}.$js_rows_to_ruby(res.results); }).catch(function(e) { #{Kernel}.$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'D1', operation: 'all'}))); })`
     end
 
     # Returns a JS Promise that resolves to a single Ruby Hash (or nil).
@@ -514,7 +514,7 @@ module Cloudflare
       js_stmt = @js
       cf = Cloudflare
       err_cls = Cloudflare::D1Error
-      `#{js_stmt}.first().then(function(res) { return res == null ? nil : #{cf}.$js_object_to_hash(res); }).catch(function(e) { #{Kernel}.$$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'D1', operation: 'first'}))); })`
+      `#{js_stmt}.first().then(function(res) { return res == null ? nil : #{cf}.$js_object_to_hash(res); }).catch(function(e) { #{Kernel}.$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'D1', operation: 'first'}))); })`
     end
 
     # Returns a JS Promise that resolves to a Ruby Hash with the D1 meta.
@@ -522,7 +522,7 @@ module Cloudflare
       js_stmt = @js
       cf = Cloudflare
       err_cls = Cloudflare::D1Error
-      `#{js_stmt}.run().then(function(res) { return #{cf}.$js_object_to_hash(res); }).catch(function(e) { #{Kernel}.$$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'D1', operation: 'run'}))); })`
+      `#{js_stmt}.run().then(function(res) { return #{cf}.$js_object_to_hash(res); }).catch(function(e) { #{Kernel}.$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'D1', operation: 'run'}))); })`
     end
   end
 
@@ -535,21 +535,21 @@ module Cloudflare
     def get(key)
       js_kv = @js
       err_cls = Cloudflare::KVError
-      `#{js_kv}.get(#{key}, "text").then(function(v) { return v == null ? nil : v; }).catch(function(e) { #{Kernel}.$$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'KV', operation: 'get'}))); })`
+      `#{js_kv}.get(#{key}, "text").then(function(v) { return v == null ? nil : v; }).catch(function(e) { #{Kernel}.$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'KV', operation: 'get'}))); })`
     end
 
     # Put a value. Returns a JS Promise.
     def put(key, value)
       js_kv = @js
       err_cls = Cloudflare::KVError
-      `#{js_kv}.put(#{key}, #{value}).catch(function(e) { #{Kernel}.$$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'KV', operation: 'put'}))); })`
+      `#{js_kv}.put(#{key}, #{value}).catch(function(e) { #{Kernel}.$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'KV', operation: 'put'}))); })`
     end
 
     # Delete a key. Returns a JS Promise.
     def delete(key)
       js_kv = @js
       err_cls = Cloudflare::KVError
-      `#{js_kv}.delete(#{key}).catch(function(e) { #{Kernel}.$$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'KV', operation: 'delete'}))); })`
+      `#{js_kv}.delete(#{key}).catch(function(e) { #{Kernel}.$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'KV', operation: 'delete'}))); })`
     end
   end
 
@@ -597,3 +597,8 @@ module Cloudflare
     end
   end
 end
+
+# Phase 6 — HTTP client foundation. Loaded as part of the Cloudflare
+# Workers adapter so user code can simply `require 'sinatra/base'`
+# and use Net::HTTP / Cloudflare::HTTP.fetch without an extra require.
+require 'cloudflare_workers/http'

--- a/lib/cloudflare_workers/http.rb
+++ b/lib/cloudflare_workers/http.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+# await: true
+#
+# Phase 6 — HTTP client foundation.
+#
+# Cloudflare::HTTP.fetch wraps globalThis.fetch (V8 / Node.js / Workers)
+# and exposes a Ruby-friendly response object. Sinatra routes use
+# `.__await__` inside a `# await: true` block, the same pattern that
+# the D1/KV/R2 wrappers use for their JS Promises.
+#
+# This module is the single bridge that lets unmodified Ruby HTTP gems
+# (Net::HTTP, Faraday adapters, OpenAI clients, etc.) reach the
+# network. There is no socket-level fallback — everything ultimately
+# goes through `globalThis.fetch`, because Cloudflare Workers does not
+# expose a TCP socket API.
+
+require 'json'
+
+module Cloudflare
+  class HTTPError < StandardError
+    attr_reader :url, :method
+    def initialize(message, url: nil, method: nil)
+      @url = url
+      @method = method
+      super("[Cloudflare::HTTP] #{method || 'GET'} #{url}: #{message}")
+    end
+  end
+
+  # Lightweight response wrapper around the JS Response object.
+  # The body is read eagerly (text()) so callers see a plain Ruby
+  # String. `headers` is a frozen Hash with lowercased string keys.
+  class HTTPResponse
+    attr_reader :status, :headers, :body, :url
+
+    def initialize(status:, headers:, body:, url:)
+      @status = status
+      @headers = headers
+      @body = body
+      @url = url
+    end
+
+    def ok?
+      @status >= 200 && @status < 300
+    end
+
+    def json
+      JSON.parse(@body)
+    end
+
+    def [](name)
+      @headers[name.to_s.downcase]
+    end
+  end
+
+  module HTTP
+    DEFAULT_HEADERS = {}.freeze
+
+    # Issue an HTTP request via globalThis.fetch.
+    #
+    #   res = Cloudflare::HTTP.fetch('https://api.example.com/users',
+    #           method: 'POST',
+    #           headers: { 'content-type' => 'application/json' },
+    #           body: { name: 'kazu' }.to_json).__await__
+    #   res.status   # => 200
+    #   res.json     # => { 'id' => 1, 'name' => 'kazu' }
+    #
+    # The whole response body is awaited and returned as a String.
+    # Use `Cloudflare::HTTPResponse#body` to access raw text.
+    def self.fetch(url, method: 'GET', headers: nil, body: nil)
+      hdrs = headers || DEFAULT_HEADERS
+      method_str = method.to_s.upcase
+      js_headers = ruby_headers_to_js(hdrs)
+      js_body = body.nil? ? nil : body.to_s
+      url_str = url.to_s
+      response_klass = Cloudflare::HTTPResponse
+      err_klass = Cloudflare::HTTPError
+      headers_to_hash = method(:js_headers_to_hash)
+      _ = headers_to_hash # silence opal lint
+
+      js_promise = `
+        (async function() {
+          var init = { method: #{method_str}, headers: #{js_headers}, redirect: 'follow' };
+          if (#{js_body} !== nil && #{js_body} != null) { init.body = #{js_body}; }
+          var resp;
+          try {
+            resp = await globalThis.fetch(#{url_str}, init);
+          } catch (e) {
+            #{Kernel}.$$raise(#{err_klass}.$new(e.message || String(e), Opal.hash({ url: #{url_str}, method: #{method_str} })));
+          }
+          var text = '';
+          try {
+            text = await resp.text();
+          } catch (e) {
+            text = '';
+          }
+          var hash_keys = [];
+          var hash_vals = [];
+          if (resp.headers && typeof resp.headers.forEach === 'function') {
+            resp.headers.forEach(function(value, key) {
+              hash_keys.push(String(key).toLowerCase());
+              hash_vals.push(String(value));
+            });
+          }
+          return { status: resp.status|0, text: text, hkeys: hash_keys, hvals: hash_vals };
+        })()
+      `
+
+      js_result = js_promise.__await__
+      hkeys = `#{js_result}.hkeys`
+      hvals = `#{js_result}.hvals`
+      h = {}
+      i = 0
+      len = `#{hkeys}.length`
+      while i < len
+        h[`#{hkeys}[#{i}]`] = `#{hvals}[#{i}]`
+        i += 1
+      end
+
+      response_klass.new(
+        status: `#{js_result}.status`,
+        headers: h,
+        body: `#{js_result}.text`,
+        url: url_str
+      )
+    end
+
+    # Convert a Ruby Hash<String, String> into a plain JS object usable
+    # as the `headers` init for fetch().
+    def self.ruby_headers_to_js(hash)
+      js_obj = `{}`
+      hash.each do |k, v|
+        ks = k.to_s
+        vs = v.to_s
+        `#{js_obj}[#{ks}] = #{vs}`
+      end
+      js_obj
+    end
+
+    # Internal: convert JS Headers / iterable to Ruby Hash with
+    # lowercased string keys. Currently inlined in fetch() but exposed
+    # for completeness.
+    def self.js_headers_to_hash(js_headers)
+      h = {}
+      `
+        if (#{js_headers} && typeof #{js_headers}.forEach === 'function') {
+          #{js_headers}.forEach(function(value, key) {
+            #{h}.$$smap[String(key).toLowerCase()] = String(value);
+          });
+        }
+      `
+      h
+    end
+  end
+end

--- a/lib/opal_patches.rb
+++ b/lib/opal_patches.rb
@@ -334,6 +334,25 @@ module ::URI
 
     Generic.new(host: host, scheme: scheme, port: port, path: path, query: query, fragment: frag)
   end
+
+  # Net::HTTP.get(URI('https://...')) is the canonical entry point in
+  # CRuby Ruby code. CRuby resolves `URI('...')` via Kernel#URI, which
+  # is defined in `uri/common.rb` as `URI.parse(arg)`. Opal's stdlib
+  # omits that; install it here so vendored gems (and our Net::HTTP
+  # shim) can use the idiomatic short form.
+  def self.HTTP_class_for(scheme)
+    HTTP if scheme == 'http'
+  end
+end
+
+# Kernel#URI(string) — CRuby alias for URI.parse(string). Phase 6
+# requires it for `Net::HTTP.get(URI('https://...'))` to work.
+module ::Kernel
+  def URI(arg)
+    return arg if arg.is_a?(::URI::Generic)
+    ::URI.parse(arg.to_s)
+  end
+  module_function :URI
 end
 
 # -----------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -10,10 +10,13 @@
     "build:opal": "OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -r cloudflare_workers -r homurabi_templates -r homurabi_assets -o build/hello.no-exit.mjs app/hello.rb 2>build/opal.stderr.log",
     "build": "npm run build:erb && npm run build:assets && npm run build:opal",
     "dev": "npm run build && wrangler dev --port 8787 --ip 127.0.0.1",
+    "d1:init": "bin/init-local-d1",
     "deploy": "npm run build && wrangler deploy",
     "build:test": "ruby bin/compile-erb && OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -r cloudflare_workers -r homurabi_templates -o build/smoke-test.mjs test/smoke.rb 2>build/opal.stderr.log",
-    "test": "npm run build:test && node build/smoke-test.mjs",
-    "clean": "rm -f build/hello.no-exit.mjs build/smoke-test.mjs build/homurabi_templates.rb build/homurabi_assets.rb build/opal.stderr.log"
+    "test": "npm run build:test && node build/smoke-test.mjs && npm run test:http",
+    "build:http-test": "OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -o build/http-smoke.mjs test/http_smoke.rb 2>build/opal.stderr.log",
+    "test:http": "npm run build:http-test && node build/http-smoke.mjs",
+    "clean": "rm -f build/hello.no-exit.mjs build/smoke-test.mjs build/http-smoke.mjs build/homurabi_templates.rb build/homurabi_assets.rb build/opal.stderr.log"
   },
   "devDependencies": {
     "wrangler": "^3.99.0"

--- a/test/http_smoke.rb
+++ b/test/http_smoke.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+# await: true
+#
+# Phase 6 — HTTP client foundation smoke tests.
+#
+# Verifies:
+#   - Cloudflare::HTTP.fetch wraps globalThis.fetch and returns
+#     a Cloudflare::HTTPResponse (status / headers / body / json).
+#   - Cloudflare::HTTP.fetch supports POST with body + headers.
+#   - Net::HTTP.get(URI) returns body string.
+#   - Net::HTTP.get_response returns Net::HTTPResponse with code/body/[].
+#   - Net::HTTP.post_form posts urlencoded form data.
+#   - URI('https://...') / URI.parse('https://...') exposes host/scheme/path.
+#
+# Usage:
+#   npm run build:http-test && node build/http-smoke.mjs
+#   — or —
+#   npm run test:http
+#
+# Tests stub globalThis.fetch so they are deterministic and offline.
+
+require 'json'
+require 'cloudflare_workers/http'
+require 'net/http'
+
+# =====================================================================
+# Stub globalThis.fetch with a deterministic mock that records the
+# last call and returns canned responses based on the URL path.
+# =====================================================================
+
+`
+globalThis.__last_fetch_call__ = null;
+globalThis.fetch = async function(url, init) {
+  init = init || {};
+  globalThis.__last_fetch_call__ = {
+    url: String(url),
+    method: init.method || 'GET',
+    headers: init.headers || {},
+    body: init.body == null ? null : String(init.body)
+  };
+  var u = new URL(String(url));
+  var path = u.pathname;
+  var status = 200;
+  var headers = new Headers({ 'content-type': 'text/plain', 'x-stub': 'on' });
+  var body = 'hello from stub';
+
+  if (path === '/json') {
+    headers = new Headers({ 'content-type': 'application/json' });
+    body = JSON.stringify({ ok: true, n: 42 });
+  } else if (path === '/echo') {
+    headers = new Headers({ 'content-type': 'text/plain' });
+    body = (init.method || 'GET') + ':' + (init.body || '');
+  } else if (path === '/notfound') {
+    status = 404;
+    body = 'gone';
+  } else if (path === '/headers') {
+    headers = new Headers({ 'content-type': 'text/plain', 'x-custom': 'received:' + (init.headers && init.headers['x-marker'] || '') });
+    body = 'ok';
+  } else if (path === '/form') {
+    headers = new Headers({ 'content-type': 'text/plain' });
+    body = 'form:' + (init.body || '');
+  }
+
+  return new Response(body, { status: status, headers: headers });
+};
+`
+
+# =====================================================================
+# Test harness (mirrors test/smoke.rb)
+# =====================================================================
+
+module SmokeTest
+  @passed = 0
+  @failed = 0
+  @errors = []
+
+  def self.assert(label, &block)
+    result = block.call
+    if result
+      @passed += 1
+      $stdout.puts "  PASS  #{label}"
+    else
+      @failed += 1
+      @errors << label
+      $stdout.puts "  FAIL  #{label}"
+    end
+  rescue Exception => e
+    @failed += 1
+    @errors << "#{label} (#{e.class}: #{e.message})"
+    $stdout.puts "  CRASH #{label} — #{e.class}: #{e.message}"
+  end
+
+  def self.report
+    total = @passed + @failed
+    $stdout.puts ""
+    $stdout.puts "#{total} tests, #{@passed} passed, #{@failed} failed"
+    if @errors.any?
+      $stdout.puts "Failures:"
+      @errors.each { |e| $stdout.puts "  - #{e}" }
+    end
+    @failed == 0
+  end
+end
+
+# =====================================================================
+# Tests
+# =====================================================================
+
+$stdout.puts "=== homurabi Phase 6 — HTTP smoke ==="
+$stdout.puts ""
+
+$stdout.puts "--- Cloudflare::HTTP.fetch ---"
+
+SmokeTest.assert("GET returns Cloudflare::HTTPResponse with status 200") {
+  res = Cloudflare::HTTP.fetch('https://example.test/').__await__
+  res.is_a?(Cloudflare::HTTPResponse) && res.status == 200
+}
+
+SmokeTest.assert("response.body returns String") {
+  res = Cloudflare::HTTP.fetch('https://example.test/').__await__
+  res.body == 'hello from stub'
+}
+
+SmokeTest.assert("response.headers is a Hash with lowercased keys") {
+  res = Cloudflare::HTTP.fetch('https://example.test/').__await__
+  res.headers['content-type'].to_s.include?('text/plain') &&
+    res.headers['x-stub'] == 'on'
+}
+
+SmokeTest.assert("response.json parses application/json body") {
+  res = Cloudflare::HTTP.fetch('https://example.test/json').__await__
+  parsed = res.json
+  parsed['ok'] == true && parsed['n'] == 42
+}
+
+SmokeTest.assert("404 response has status 404 and body 'gone'") {
+  res = Cloudflare::HTTP.fetch('https://example.test/notfound').__await__
+  res.status == 404 && res.body == 'gone' && !res.ok?
+}
+
+SmokeTest.assert("ok? is true for 2xx, false otherwise") {
+  ok  = Cloudflare::HTTP.fetch('https://example.test/').__await__.ok?
+  bad = Cloudflare::HTTP.fetch('https://example.test/notfound').__await__.ok?
+  ok == true && bad == false
+}
+
+SmokeTest.assert("POST with body sends the body to the server") {
+  res = Cloudflare::HTTP.fetch('https://example.test/echo',
+                               method: 'POST', body: 'hi-there').__await__
+  res.body == 'POST:hi-there'
+}
+
+SmokeTest.assert("POST forwards custom headers") {
+  res = Cloudflare::HTTP.fetch('https://example.test/headers',
+                               method: 'POST',
+                               headers: { 'x-marker' => 'm1' }).__await__
+  res.headers['x-custom'].to_s.include?('received:m1')
+}
+
+$stdout.puts ""
+$stdout.puts "--- Net::HTTP shim ---"
+
+# Note on # await: true semantics — Opal compiles every method body in
+# this file as async, so any helper that itself awaits a Promise still
+# returns a Promise. Sinatra routes (and these tests) need an explicit
+# `.__await__` on the call site, exactly like the D1/KV/R2 wrappers.
+SmokeTest.assert("Net::HTTP.get(URI) returns body String") {
+  body = Net::HTTP.get(URI('https://example.test/')).__await__
+  body == 'hello from stub'
+}
+
+SmokeTest.assert("Net::HTTP.get(URI) accepts an HTTP URL") {
+  body = Net::HTTP.get(URI('http://example.test/')).__await__
+  body == 'hello from stub'
+}
+
+SmokeTest.assert("Net::HTTP.get_response returns Net::HTTPResponse with code/body") {
+  res = Net::HTTP.get_response(URI('https://example.test/json')).__await__
+  res.is_a?(Net::HTTPResponse) && res.code == '200' && res.body.include?('"ok":true')
+}
+
+SmokeTest.assert("Net::HTTPResponse#[] reads a header (case insensitive)") {
+  res = Net::HTTP.get_response(URI('https://example.test/json')).__await__
+  res['content-type'].to_s.include?('application/json') &&
+    res['Content-Type'].to_s.include?('application/json')
+}
+
+SmokeTest.assert("Net::HTTP.post_form sends urlencoded body") {
+  res = Net::HTTP.post_form(URI('https://example.test/form'),
+                            'name' => 'kazu', 'lang' => 'ja').__await__
+  # body comes back as 'form:<urlencoded>'; both keys must appear
+  b = res.body
+  b.start_with?('form:') && b.include?('name=kazu') && b.include?('lang=ja')
+}
+
+$stdout.puts ""
+$stdout.puts "--- URI sanity (Phase 6 prerequisites) ---"
+
+SmokeTest.assert("URI.parse('https://x.test/p?q=1#f') exposes scheme/host/path/query/fragment") {
+  u = URI.parse('https://x.test/p?q=1#f')
+  u.scheme == 'https' && u.host == 'x.test' && u.path == '/p' && u.query == 'q=1' && u.fragment == 'f'
+}
+
+# =====================================================================
+# Report
+# =====================================================================
+success = SmokeTest.report
+`process.exit(#{success ? 0 : 1})`

--- a/test/smoke.rb
+++ b/test/smoke.rb
@@ -255,6 +255,41 @@ SmokeTest.assert("Cloudflare::BindingError carries binding_type") {
   e.binding_type == 'D1' && e.operation == 'all' && e.message.include?('D1')
 }
 
+# Phase 6.x — Regression test for the Phase 3 catch handler.
+# Before: `Kernel.$$raise(...)` (typo) made every D1 / KV failure
+# crash with "is not a function" instead of raising D1Error / KVError.
+# This test fakes a JS binding whose .all() returns a rejected Promise
+# and asserts that Ruby code can rescue Cloudflare::D1Error normally.
+SmokeTest.assert("D1 catch handler raises Cloudflare::D1Error (regression)") {
+  fake_db = `({
+    prepare: function(sql) {
+      return { all: function() { return Promise.reject(new Error('no such table: users')); } };
+    }
+  })`
+  db = Cloudflare::D1Database.new(fake_db)
+  raised = nil
+  begin
+    db.prepare('SELECT * FROM users').all.__await__
+  rescue Cloudflare::D1Error => e
+    raised = e
+  end
+  raised && raised.message.include?('no such table') && raised.binding_type == 'D1'
+}
+
+SmokeTest.assert("KV catch handler raises Cloudflare::KVError (regression)") {
+  fake_kv = `({
+    get: function(k, opts) { return Promise.reject(new Error('kv unavailable')); }
+  })`
+  kv = Cloudflare::KVNamespace.new(fake_kv)
+  raised = nil
+  begin
+    kv.get('missing').__await__
+  rescue Cloudflare::KVError => e
+    raised = e
+  end
+  raised && raised.message.include?('kv unavailable') && raised.binding_type == 'KV'
+}
+
 $stdout.puts ""
 $stdout.puts "--- Helpers ---"
 SmokeTest.assert("db/kv/bucket helpers are defined on App") {

--- a/vendor/net/http.rb
+++ b/vendor/net/http.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+# await: true
+#
+# Minimal Net::HTTP shim for Cloudflare Workers / Opal.
+#
+# This is NOT a port of CRuby's Net::HTTP. Cloudflare Workers does
+# not expose raw TCP sockets, so the only available transport is the
+# global `fetch()` API. Net::HTTP here is a thin compatibility layer
+# delegating to Cloudflare::HTTP.fetch.
+#
+# Covered surface (the 95% of Net::HTTP usage we see in real Ruby):
+#   - Net::HTTP.get(URI)            -> body String
+#   - Net::HTTP.get_response(URI)   -> Net::HTTPResponse
+#   - Net::HTTP.post_form(URI, hash)-> Net::HTTPResponse
+#   - Net::HTTPResponse#body / #code / #[] / #message / #header
+#
+# Anything else (start blocks, persistent connections, basic auth via
+# request objects, multipart, chunked streaming) is out of scope for
+# Phase 6. Use Cloudflare::HTTP.fetch directly for those.
+
+require 'cloudflare_workers/http'
+
+module Net
+  # Net::HTTPResponse — minimal CRuby compatibility surface.
+  class HTTPResponse
+    attr_reader :body, :headers
+
+    def initialize(cloudflare_response)
+      @cf = cloudflare_response
+      @body = cloudflare_response.body
+      @headers = cloudflare_response.headers
+    end
+
+    # CRuby's Net::HTTPResponse#code returns a String like "200".
+    def code
+      @cf.status.to_s
+    end
+
+    # Loose mapping; CRuby returns the HTTP status text. We synthesize
+    # a label from the status code so callers that only check existence
+    # do not blow up.
+    def message
+      case @cf.status
+      when 200 then 'OK'
+      when 201 then 'Created'
+      when 204 then 'No Content'
+      when 301 then 'Moved Permanently'
+      when 302 then 'Found'
+      when 400 then 'Bad Request'
+      when 401 then 'Unauthorized'
+      when 403 then 'Forbidden'
+      when 404 then 'Not Found'
+      when 500 then 'Internal Server Error'
+      when 502 then 'Bad Gateway'
+      when 503 then 'Service Unavailable'
+      else 'HTTP ' + @cf.status.to_s
+      end
+    end
+
+    # Case-insensitive header read, like CRuby Net::HTTPHeader#[].
+    def [](name)
+      @headers[name.to_s.downcase]
+    end
+
+    # Iterate headers (lowercased keys).
+    def each_header(&block)
+      @headers.each(&block)
+    end
+    alias_method :each, :each_header
+
+    # CRuby uses #header for raw access; surface a Hash here.
+    def header
+      @headers
+    end
+  end
+
+  module HTTP
+    # GET the URL and return the body as a String. Mirrors
+    # Net::HTTP.get(URI).
+    def self.get(uri_or_url)
+      url = uri_to_url(uri_or_url)
+      Cloudflare::HTTP.fetch(url, method: 'GET').__await__.body
+    end
+
+    # GET and return a Net::HTTPResponse.
+    def self.get_response(uri_or_url)
+      url = uri_to_url(uri_or_url)
+      cf_res = Cloudflare::HTTP.fetch(url, method: 'GET').__await__
+      Net::HTTPResponse.new(cf_res)
+    end
+
+    # POST a Hash as application/x-www-form-urlencoded.
+    def self.post_form(uri_or_url, params)
+      url = uri_to_url(uri_or_url)
+      body = encode_form(params)
+      cf_res = Cloudflare::HTTP.fetch(
+        url,
+        method: 'POST',
+        headers: { 'content-type' => 'application/x-www-form-urlencoded' },
+        body: body
+      ).__await__
+      Net::HTTPResponse.new(cf_res)
+    end
+
+    # Internal: accept a URI::Generic or a String/anything respond_to?(:to_s).
+    def self.uri_to_url(uri_or_url)
+      return uri_or_url.to_s unless uri_or_url.respond_to?(:scheme)
+      scheme = uri_or_url.scheme || 'http'
+      host = uri_or_url.host || ''
+      port = uri_or_url.port
+      path = uri_or_url.path || '/'
+      path = '/' if path.empty?
+      query = uri_or_url.respond_to?(:query) ? uri_or_url.query : nil
+      authority = if port && !default_port?(scheme, port)
+                    host + ':' + port.to_s
+                  else
+                    host
+                  end
+      url = scheme + '://' + authority + path
+      url = url + '?' + query if query && !query.empty?
+      url
+    end
+
+    def self.default_port?(scheme, port)
+      (scheme == 'http' && port == 80) || (scheme == 'https' && port == 443)
+    end
+
+    def self.encode_form(params)
+      pairs = []
+      params.each do |k, v|
+        ek = url_encode(k.to_s)
+        ev = url_encode(v.to_s)
+        pairs << (ek + '=' + ev)
+      end
+      pairs.join('&')
+    end
+
+    def self.url_encode(s)
+      `encodeURIComponent(#{s}).replace(/%20/g, '+')`
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Phase 6 — HTTP client foundation**: `Cloudflare::HTTP.fetch` (wrapping `globalThis.fetch`), a `Net::HTTP` shim (`get` / `get_response` / `post_form`), and `Kernel#URI` so unmodified Ruby HTTP code reaches the network through the Workers fetch API.
- **Latent bug fix from Phase 3**: six `Kernel.$$raise` typos in D1/KV catch handlers (constant-lookup prefix instead of method-call prefix) made local 500s opaque. Fixed to `Kernel.$raise`, with two regression tests.
- **Local D1 setup**: `bin/init-local-d1` + `bin/schema.sql` (manual, `--local`-only, idempotent — never touches production D1).

## Test plan

- [x] Implementation: `npm run build` passes (5.4MB / gzip 1.13MB, no size change)
- [x] Smoke: `npm test` 41/41 green (existing 25 + 2 D1/KV catch regressions + 14 HTTP)
- [x] Manual: `wrangler dev --local` returns 200 on `/`, `/d1/users`, `/demo/http`, `/demo/http/raw`
- [x] Demo `/demo/http` and `/demo/http/raw` hit ipify and return real edge IP
- [x] Local D1 init script verified idempotent (re-runs without destroying data)
- [x] Production safety: `bin/init-local-d1` enforces `--local`, never auto-runs

## What's new for Web devs

Cloudflare-edge Sinatra routes can now call any HTTP API:

```ruby
get '/example' do
  content_type 'application/json'
  res = Net::HTTP.get_response(URI('https://api.example.com/items')).__await__
  { 'status' => res.code, 'items' => JSON.parse(res.body) }.to_json
end
```

This unblocks Phase 8 (JWT) external IdP exchange and Phase 10 (AI) fallback to OpenAI-compatible APIs.

## Evidence

Local artifacts (not tracked in git, see worktree `.artifacts/phase6-fetch/`):

- Screenshots: `/`, `/d1/users`, `/demo/http`, `/demo/http/raw` after fix
- Test output: 41/41 PASS
- REPORT.md with full design notes + commit-construction rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)