### PR TITLE
docs: update ROADMAP — Phase 6/7 shipped, refine Phase 8 with Phase 7 primitives

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,8 @@
 # homurabi ロードマップ
 
-> 本ドキュメントは Phase 6 以降の中長期計画。
-> Phase 1〜5（コア基盤・D1/KV/R2 バインディング・ERB プリコンパイル・回帰テスト 25 件）は完了済み。
+> Phase 1〜7 完了。Phase 8 以降が中長期計画。
+> Phase 1〜5（コア基盤・D1/KV/R2 バインディング・ERB プリコンパイル・回帰 25 件）
+> および Phase 6（HTTP fetch シム）、Phase 7（フル暗号スイート）は ship 済み。
 >
 > 方針メモ:
 > - **クライアント側（ブラウザ）で完結できる仕事は Worker でやらない**。
@@ -11,140 +12,149 @@
 >   「永続ストレージ」「AI/エッジ計算」** に効く機能のみ。
 > - 各 Phase は **1 worktree = 1 Phase**。実装→ドッグフーディング→reviw レビュー
 >   →マスター承認、の順を厳守する（CLAUDE.md ルール準拠）。
+> - **「妥協選択肢を出すのは禁止」「最大工数で全部実装」**（Phase 7 マスター指示）。
+>   不足はNG・追加はOK。プラットフォーム制約で物理不能なものは明記してスキップ。
 
 ---
 
 ## 全体像
 
 ```
-Phase 6 ── HTTP クライアント基盤        (Net::HTTP/Faraday → fetch シム)
+✅ Phase 6  ── HTTP クライアント基盤        (Net::HTTP / Cloudflare::HTTP.fetch)
+   │            shipped 2026-04-17 (PR #1)
+   ↓
+✅ Phase 7  ── 暗号プリミティブ完全実装    (Digest / HMAC / Cipher / RSA / EC / Ed25519 /
+   │            X25519 / KDF / BN — node:crypto sync + subtle async hybrid)
+   │            shipped 2026-04-17 (PR #2)
+   ↓
+🚧 Phase 8  ── JWT 認証フレームワーク       (jwt gem 動作 + Sinatra ヘルパ)
    │
-Phase 7 ── Web Crypto 実体化            (Digest / HMAC / SHA / Random)
-   │           ↑ Phase 8 の前提
-Phase 8 ── JWT 認証フレームワーク       (jwt gem 動作 + Sinatra ヘルパ)
+   ├─ 並列可
    │
-Phase 9 ── Scheduled Workers (Cron)     (scheduled handler + DSL)
+🚧 Phase 9  ── Scheduled Workers (Cron)     (scheduled handler + DSL)
    │
-Phase 10 ── Workers AI バインディング   (env.AI ラッパ + Sinatra AI チャットデモ)
+🚧 Phase 10 ── Workers AI バインディング   (env.AI ラッパ + Sinatra AI チャットデモ
+                                              with Gemma 4 + gpt-oss-120b)
+🚧 Phase 11 候補 — Vectorize / Durable Objects / Queues / Cache API / Email
 ```
 
 依存関係:
-- Phase 7 は **Phase 8 の前提**（JWT は HMAC が必須）
-- Phase 6 は **Phase 10 で OpenAI 互換 API を叩く時に再利用可能**（任意の外部 LLM
-  をフォールバックに使うパターン）
+- ✅ Phase 7 完了により **Phase 8 の前提（HS/RS/PS/ES/EdDSA 全 algo の sign/verify）が
+  すべて揃っている**。jwt gem を vendor して薄いパッチ当てれば即動く見込み
+- Phase 6 は **Phase 10 で OpenAI 互換 API を叩く時に再利用可能**
 - Phase 9 と Phase 10 は独立、並列可
 
 ---
 
-## Phase 6 — HTTP クライアント基盤（fetch シム）
+## ✅ Phase 6 — HTTP クライアント基盤（fetch シム） — **shipped (PR #1)**
 
-### 目的
-Ruby Gem 資産の中で **最も波及効果が大きい** のが HTTP クライアント。
-Net::HTTP / Faraday / OpenAI クライアント / API ラッパ等、すべてが
-この層に依存している。Cloudflare Workers のグローバル `fetch()` を
-Ruby 側から自然に呼べるようにする。
+`Cloudflare::HTTP.fetch` で `globalThis.fetch` を Ruby から呼べるようにし、
+`Net::HTTP` シム（`get` / `get_response` / `post_form`）で既存 Ruby HTTP コードを
+そのまま動かす。`Kernel#URI` も追加。
 
-### スコープ
-- `lib/cloudflare_workers/http.rb`（新規）
-  - `Cloudflare::HTTP.fetch(url, method:, headers:, body:)` を実装
-  - 戻り値は `Cloudflare::HTTPResponse`（status / headers / body / json メソッド）
-  - 内部は JS の `fetch()` に `.__await__` でブリッジ
-- **Net::HTTP シム**: `vendor/net/http.rb`（新規スタブ）
-  - `Net::HTTP.get(uri)` / `Net::HTTP.get_response(uri)` / `Net::HTTP.post_form(uri, params)`
-  - 内部で `Cloudflare::HTTP.fetch` に委譲
-  - `Net::HTTPResponse#body` / `#code` / `#[]` 互換
-- **URI 周りの補強**（`lib/opal_patches.rb` の URI を URI::HTTP / URI::HTTPS 解析対応に）
-- **Faraday は Phase 6 では入れない**（Phase 6.1 として後追い）
-
-### 非スコープ
-- 生 TCP / Net::TCP / OpenSSL Socket（Workers が socket API を持たないため不可）
-- HTTP/2 push、長時間 keep-alive
-- WebSocket クライアント（Phase 10 以降で Durable Objects と一緒に検討）
-
-### 完了条件
-1. `Net::HTTP.get(URI('https://example.com'))` が ESM 内で動く
-2. `Cloudflare::HTTP.fetch` が POST + JSON ボディ + ヘッダ送信できる
-3. 回帰テストに `test/http_smoke.rb` を追加（テスト数 +6）
-4. README に "Net::HTTP works" の節を追加
-
-### 想定リスク
-- `fetch()` の Response.body は ReadableStream → 一旦 `.text()` / `.arrayBuffer()`
-  で全部読む方式にする（Workers の CPU 制限内なら問題なし）
-- リダイレクトは `redirect: 'follow'` 既定でユーザに見せず吸収
+### 実装内容（commit `48c37a7`）
+- `lib/cloudflare_workers/http.rb` — `Cloudflare::HTTP.fetch` + `HTTPResponse`
+- `vendor/net/http.rb` — `Net::HTTP.{get, get_response, post_form}` + `Net::HTTPResponse`
+- `lib/opal_patches.rb` — `Kernel#URI(...)` 追加
+- 副次成果: Phase 3 期に書かれてた `Kernel.$$raise` typo を発見して fix
+  + 回帰テスト 2 本追加（D1Error / KVError 正常 raise）
+- `bin/init-local-d1` + `bin/schema.sql`（手動実行・local only・冪等）
+- 14 本の HTTP smoke + デモルート 2 本（`/demo/http`, `/demo/http/raw`）
 
 ---
 
-## Phase 7 — Web Crypto 実体化（Digest / HMAC）
+## ✅ Phase 7 — 暗号プリミティブ完全実装 — **shipped (PR #2)**
 
-### 目的
-現状 `vendor/digest.rb` は **NotImplementedError を投げるだけのスタブ**。
-JWT 署名検証、CSRF トークン、Cookie 暗号化、すべてここで詰まる。
-Web Crypto API (`crypto.subtle`) に委譲して実体化する。
+Cloudflare Workers で動く全暗号 algo を実装。**JWT 全 algo (HS/RS/PS/ES/EdDSA) +
+RSA-OAEP + AES-GCM/CBC/CTR + ECDH + X25519 + KDF + 完全 BN**。
 
-### スコープ
-- `vendor/digest.rb` を **本物の実装** に置き換え
-  - `Digest::SHA256.hexdigest(str)` → `crypto.subtle.digest('SHA-256', ...)` を await
-  - `Digest::SHA1`, `Digest::SHA512`, `Digest::MD5` も同様
-  - 同期 API に見せるため、**ビルド時 magic comment `# await: true` を付与**
-- `vendor/openssl.rb`（新規・最小）
-  - `OpenSSL::HMAC.hexdigest(digest, key, data)` を `crypto.subtle.sign('HMAC', ...)` で実装
-  - `OpenSSL::Digest::SHA256` 等のエイリアス
-- `SecureRandom` は既に `lib/opal_patches.rb` で実装済み → 流用
+### 設計
+- **node:crypto sync**（Hash / HMAC / KDF / Random / KeyGen / PEM I/O）
+- **Web Crypto subtle async**（Cipher / Sign / Verify — Workers の `nodejs_compat`
+  が `createCipheriv` / `createSign` / `createVerify` / `publicEncrypt` 未実装
+  なため subtle で代替）
+- async API は `# await: true` + `.__await__`（D1/KV/R2 と同じパターン）
 
-### 非スコープ
-- RSA / EC 鍵生成（必要になったら Phase 7.1）
-- 証明書パース（X.509）
+### 実装内容（commit `4f53fa1`）
+| カテゴリ | 実装 |
+|---|---|
+| Digest | SHA1/256/384/512/MD5（`vendor/digest.rb`） |
+| HMAC | 5 algos |
+| Cipher | AES-128/192/256-GCM/CBC/CTR — GCM auth_tag/AAD/tampering、CTR 真の streaming、バイト透過 |
+| PKey::RSA | gen / PEM / sign / verify (PKCS1) / sign_pss / verify_pss (PSS) / public_encrypt / private_decrypt (OAEP) |
+| PKey::EC | P-256/384/521 gen / PEM / sign (DER) / verify (DER) / sign_jwt (raw R\|\|S) / verify_jwt / dh_compute_key |
+| PKey::Ed25519 | gen / PEM / sign / verify (EdDSA) |
+| PKey::X25519 | gen / PEM / dh_compute_key |
+| KDF | PBKDF2-HMAC / HKDF |
+| BN | JS BigInt 完全実装（+ - * / % ** mod_exp gcd 比較 num_bits to_s(radix)） |
+| SecureRandom | hex / random_bytes / urlsafe_base64 / uuid |
+| Workers self-test | `GET /test/crypto`（17 case）+ `bin/test-on-workers`（CI 相当） |
 
-### 完了条件
-1. `Digest::SHA256.hexdigest('hello')` が CRuby と同じ結果
-2. `OpenSSL::HMAC.hexdigest('SHA256', key, msg)` が CRuby と同じ結果
-3. 回帰テスト `test/crypto_smoke.rb` で確定値テスト（テスト数 +5）
-4. **Phase 8 (JWT) のブロッカー解消** を README に明記
+### 検証
+- 126/126 テスト緑（既存 27 + http 14 + crypto 85）
+- Workers 実機 self-test 17/17 PASS
+- Bundle: 5.5MB / gzip 1.15MB（+20KB vs Phase 6）
 
-### 想定リスク
-- Web Crypto は基本 async → Opal の `# await: true` で同期化
-- `# await: true` を入れた関数のスタックは callstack 1 段増えるが、
-  Sinatra ルートの `__await__` と同じパターンなので既知の整合性で OK
+### プラットフォーム制約で見送り（明記済）
+- **ChaCha20-Poly1305**: Web Crypto 標準にも nodejs_compat にもなし。
+  pure-JS AEAD 同梱が必要、本 Phase では deferred
+- **AES-GCM/CBC mid-block streaming**: subtle が atomic single-shot のため不可。
+  CTR は真の streaming 可能（実装済）
+- **RSA-PKCS1 v1.5 encrypt**: subtle は OAEP のみ。OAEP（モダン推奨）を使う
 
 ---
 
-## Phase 8 — JWT 認証フレームワーク
+## 🚧 Phase 8 — JWT 認証フレームワーク
 
 ### 目的
-Workers エッジでの API 認証は基本 JWT。`jwt` gem を本物で動かしつつ、
-Sinatra に薄い helper を被せて DSL 化する。
+Workers エッジの API 認証は基本 JWT。`jwt` gem を vendor し、Sinatra に
+薄い helper を被せて DSL 化する。**Phase 7 で全 algo の primitives が
+揃ったので、jwt gem は最小限のパッチで動く見込み**。
 
 ### スコープ
 - `vendor/jwt/`（新規 vendor）
-  - `jwt` gem 本体を vendor、必要なパッチを適用
-  - 対応アルゴリズム: HS256 / HS384 / HS512（Phase 7 の HMAC を使用）
-  - RS256 / ES256 は Phase 8.1 に分離（鍵生成が必要なため）
+  - `ruby-jwt` gem 本体を vendor、Opal 互換パッチを適用
+  - **Phase 7 で揃った primitives を使うため、対応 alg は最初から包括的**:
+    - HS256 / HS384 / HS512（OpenSSL::HMAC）
+    - RS256 / RS384 / RS512（OpenSSL::PKey::RSA#sign / verify、要 `.__await__`）
+    - PS256 / PS384 / PS512（OpenSSL::PKey::RSA#sign_pss / verify_pss）
+    - ES256 / ES384 / ES512（OpenSSL::PKey::EC#sign_jwt / verify_jwt — raw R\|\|S）
+    - EdDSA（OpenSSL::PKey::Ed25519#sign / verify）
+  - JWE（暗号化 JWT）は Phase 8.1 候補
 - `lib/sinatra/jwt_auth.rb`（新規 Sinatra 拡張）
   - `helpers do; def current_user; end; end` を提供
   - `before { authenticate! }` でルート保護
   - `Authorization: Bearer xxx` ヘッダから抽出
 - デモルートを `app/hello.rb` に追加
-  - `POST /api/login` → JWT 発行
+  - `POST /api/login` → JWT 発行（HS256 / RS256 / ES256 / EdDSA から選択可能）
   - `GET /api/me` → JWT 検証して current_user 返却
+  - `POST /api/login/refresh` → KV 永続 refresh token
+
+### 想定リスク + 対処
+- **jwt gem 内部の Sign/Verify が sync 前提** → Phase 7 の sign/verify は
+  subtle 経由で async（Promise を返す）。jwt gem 内の RSA/EC sign 呼び出し
+  サイトに `.__await__` を仕込む小パッチが必要。HMAC は元々 sync なので無修正で動く。
+- **jwt gem の `String#unpack` 多用** → Phase 7 で `unpack1('H*')` パッチ済、
+  他の format は smoke で確認しながら追加対応
+- **RS/PS/ES の jwt gem 既定エンコード形式**: ES は raw R||S（JWT 標準）→
+  Phase 7 の `sign_jwt`/`verify_jwt` をそのまま使える
 
 ### 非スコープ
 - OAuth フロー全体（IdP との連携は別 Phase）
-- Refresh Token の永続化（KV を使えばすぐできるが、まず JWT 単体）
+- JWE（暗号化 JWT）
 
 ### 完了条件
 1. `JWT.encode(payload, secret, 'HS256')` が CRuby の jwt gem と同じトークンを返す
 2. `JWT.decode(token, secret, true, algorithm: 'HS256')` が動く
-3. デモルート `/api/login` → `/api/me` が E2E で通る
-4. 回帰テスト `test/jwt_smoke.rb`（テスト数 +6）
-5. README に「JWT 認証」の節を追加
-
-### 想定リスク
-- jwt gem は Base64 / JSON / OpenSSL に依存 → Phase 7 完了が前提
-- `jwt` の内部で `String#unpack` を多用 → Opal の挙動を smoke で確認
+3. RS256 / PS256 / ES256 / EdDSA 全部 round-trip
+4. デモルート `/api/login` → `/api/me` が E2E で通る
+5. 回帰テスト `test/jwt_smoke.rb`（最低 12 本: 各 alg の encode/decode）
+6. Workers self-test に JWT cases 追加
+7. README に「JWT 認証」の節を追加
 
 ---
 
-## Phase 9 — Scheduled Workers (Cron Triggers)
+## 🚧 Phase 9 — Scheduled Workers (Cron Triggers)
 
 ### 目的
 Cloudflare Workers の `scheduled` ハンドラを Ruby 側から書けるようにする。
@@ -156,14 +166,13 @@ Cloudflare Workers の `scheduled` ハンドラを Ruby 側から書けるよう
 - `lib/cloudflare_workers.rb` に Scheduled ディスパッチャを追加
   - `event.cron` / `event.scheduledTime` を Ruby に渡す
 - **Sinatra に "schedule" DSL を追加**（独自拡張）
-  - ```ruby
-    class App < Sinatra::Base
-      schedule '*/5 * * * *' do
-        # 5分ごと実行
-      end
+  ```ruby
+  class App < Sinatra::Base
+    schedule '*/5 * * * *' do
+      # 5分ごと実行
     end
-    ```
-  - 内部的には fetch ハンドラとは別のコールバック登録
+  end
+  ```
 - `wrangler.toml` に `[triggers] crons = [...]` の例を追加
 
 ### 非スコープ
@@ -173,7 +182,7 @@ Cloudflare Workers の `scheduled` ハンドラを Ruby 側から書けるよう
 ### 完了条件
 1. `wrangler dev --test-scheduled` で Ruby ハンドラが呼ばれる
 2. `schedule '*/1 * * * *'` の DSL が複数登録できる
-3. 回帰テスト `test/scheduled_smoke.rb`（テスト数 +3）
+3. 回帰テスト `test/scheduled_smoke.rb`（最低 3 本）
 4. デモ: 5分ごとに D1 に行を入れる Cron を README に記載
 
 ### 想定リスク
@@ -183,7 +192,7 @@ Cloudflare Workers の `scheduled` ハンドラを Ruby 側から書けるよう
 
 ---
 
-## Phase 10 — Workers AI バインディング + Sinatra AI チャットデモ
+## 🚧 Phase 10 — Workers AI バインディング + Sinatra AI チャットデモ
 
 ### 目的
 **最大の "映え" ポイント**。Sinatra で書いた AI チャット UI が、
@@ -191,14 +200,14 @@ Cloudflare Workers の `scheduled` ハンドラを Ruby 側から書けるよう
 をフォールバックに）を叩く。
 "Real Sinatra on the Edge with Real OSS LLM" を README のヒーローに据える。
 
-#### 採用モデル（優先順・2026-04-17 時点の Cloudflare 公式カタログ調査結果）
+### 採用モデル（優先順・2026-04-17 時点の Cloudflare 公式カタログ調査結果）
 
 | 役割 | モデルID | コスト ($/M tok 入/出) | コンテキスト | 日本語 |
 |---|---|---|---|---|
 | **主役** | `@cf/google/gemma-4-26b-a4b-it` | $0.10 / $0.30 | **256K** | ◯（140+言語） |
 | フォールバック | `@cf/openai/gpt-oss-120b` | $0.35 / $0.75 | 128K | ◯ |
 
-#### 不採用（旧メジャー除外ポリシー・マスター方針反映）
+### 不採用（旧メジャー除外ポリシー・マスター方針反映）
 - `@cf/qwen/qwen3-30b-a3b-fp8` — **plain Qwen3 は古い**（既に Qwen 3.5 / 3.6
   が出ているため、それらが Workers AI に上がるまで採用見送り）
 - `@cf/openai/gpt-oss-20b` — マスター指示により不採用
@@ -211,7 +220,7 @@ Cloudflare Workers の `scheduled` ハンドラを Ruby 側から書けるよう
 - `@cf/mistralai/mistral-small-3.1-24b-instruct` — 日本語性能が
   Gemma4 比で弱いため不採用
 
-#### 検証手順（Phase 10 着手時に必須）
+### 検証手順（Phase 10 着手時に必須）
 1. `wrangler ai models list` で採用 2 モデルの存在を確認
 2. 各モデルに「日本語で挨拶して」を投げて出力品質を smoke チェック
 3. 公式ドキュメントで料金・コンテキスト窓を再確認（変動するため）
@@ -224,7 +233,7 @@ Cloudflare Workers の `scheduled` ハンドラを Ruby 側から書けるよう
 - `lib/cloudflare_workers/ai.rb`（新規）
   - `Cloudflare::AI.run(model, inputs)` → JS の `env.AI.run(...)` を `.__await__`
   - 戻り値は Hash（`response` / `usage` 等）
-  - ストリーミングは Phase 10.1 では非対応（次節）
+  - ストリーミングは Phase 10.1 では非対応（10.3 で対応）
 - `wrangler.toml` に `[ai] binding = "AI"` の例
 - `env['cloudflare.AI']` で Sinatra ルートから取得可能に
 
@@ -233,6 +242,7 @@ Cloudflare Workers の `scheduled` ハンドラを Ruby 側から書けるよう
   - `GET /chat` → ERB で会話 UI
   - `POST /chat/messages` → Workers AI を呼んで JSON 返却
   - **会話履歴は KV に保存**（Phase 5 の KV ラッパを再利用）
+  - **JWT 認証で保護**（Phase 8 の `authenticate!` を使う）← Phase 8 完了が前提
 - `views/chat.erb` / `views/_message.erb`（新規）
 - 最小フロントは vanilla JS + fetch、アニメーションはなし
 - 既定モデルは `@cf/google/gemma-4-26b-a4b-it`
@@ -240,11 +250,11 @@ Cloudflare Workers の `scheduled` ハンドラを Ruby 側から書けるよう
 - モデル ID は `app/chat.rb` 冒頭で `MODELS = { primary: ..., fallback: [...] }`
   として定数化、差し替え容易に
 
-#### 10.3 ストリーミングレスポンス対応（任意・後追い）
+#### 10.3 ストリーミングレスポンス対応
 - Workers AI の `stream: true` を Server-Sent Events で返す
 - Cloudflare Workers の `Response(ReadableStream)` を Sinatra から返せるよう
   `lib/cloudflare_workers.rb` の build_js_response を拡張
-- これは **Phase 10.2 までで動いてから検討**（最初は同期で十分映える）
+- 10.2 までで動いてから検討
 
 ### 非スコープ
 - ベクトル DB (Vectorize) との RAG（Phase 11 候補）
@@ -256,8 +266,9 @@ Cloudflare Workers の `scheduled` ハンドラを Ruby 側から書けるよう
    が動く（`gpt-oss-120b` フォールバックも smoke テストで検証）
 2. `/chat` UI で会話が成立する（ブラウザでドッグフーディング）
 3. 会話履歴が KV に永続化されてリロード後も復元される
-4. 回帰テスト `test/ai_smoke.rb`（モック Worker AI で）（テスト数 +4）
-5. **README のヒーローセクションを書き換え**: "Sinatra + Workers AI チャット"
+4. JWT 認証で保護されたエンドポイントになる
+5. 回帰テスト `test/ai_smoke.rb`（モック Worker AI で）（最低 4 本）
+6. **README のヒーローセクションを書き換え**: "Sinatra + Workers AI チャット"
    のスクリーンショット/GIF を最上部に
 
 ### 想定リスク
@@ -273,26 +284,35 @@ Cloudflare Workers の `scheduled` ハンドラを Ruby 側から書けるよう
 
 ---
 
-## Phase 11 候補（参考・未確定）
+## 🚧 Phase 11 候補（参考・未確定）
 
-- Vectorize binding（RAG）
-- Durable Objects ラッパ（WebSocket / 永続セッション）
-- Queues binding
-- Cache API ラッパ
-- Email Workers
-- Service Bindings
-- multipart/form-data の本格対応
+| 候補 | 概要 | 価値 |
+|---|---|---|
+| Vectorize binding | RAG / セマンティック検索 | Phase 10 の AI チャットを KB 連携へ拡張 |
+| Durable Objects ラッパ | WebSocket / 永続セッション / アクター | リアルタイム機能、AI チャットのストリーム永続化 |
+| Queues binding | バックグラウンド job | 非同期処理、retry、Phase 9 と組み合わせ |
+| Cache API ラッパ | エッジキャッシュ | 低レイテンシ最適化 |
+| Email Workers | メール受信→ Ruby ハンドラ | Webhook 的にメール処理 |
+| Service Bindings | Worker→ Worker 間呼び出し | マイクロサービス分割 |
+| ChaCha20-Poly1305 | pure-JS AEAD 同梱 | Phase 7 で deferred、TLS 1.3 互換性 |
+| multipart/form-data 本格対応 | アップロード | ファイル受信、画像処理連携 |
+| Faraday アダプタ | Ruby HTTP gem 互換性 | Phase 6 の Net::HTTP に続く |
+| JWE（暗号化 JWT） | 機密 payload を含む JWT | Phase 8 の延長 |
 
 ---
 
 ## 進行ルール
 
-1. **1 Phase = 1 worktree**: `git wt feature/phase6-fetch` のように切って作業
+1. **1 Phase = 1 worktree**: `git wt feature/phase8-jwt` のように切って作業
 2. **実装後、自分で `npm run dev` 起動 → ブラウザで触る** → ドッグフーディング必須
-3. **回帰テスト追加** → `test/smoke.rb` に統合または新規ファイル
-4. **`.artifacts/<branch>/REPORT.md` に証跡** → スクショ・テスト出力・ベンチ
+3. **回帰テスト追加** → `test/<phase>_smoke.rb` 新規 + `test/smoke.rb` に統合判断
+4. **`.artifacts/<branch>/REPORT.md` に証跡** → スクショ・テスト出力・ベンチ・妥協点
 5. **`/reviw-plugin:done` でレビュー起動** → マスター承認まで PR 出さない
 6. **承認後、PR 作成 → マージ → README 更新 → ロードマップから消す**
+7. **「妥協は禁止」** — 不足はNG、追加はOK、最大工数で全部実装。プラットフォーム制約で
+   物理的に不可能なものは明記してスキップ（憶測でスキップしない、必ず実機 probe）
+8. **Workers self-test 必須** — Node テストだけでなく `bin/test-on-workers`
+   相当の in-Worker 検証を必ず追加（Phase 7 で確立した pattern）
 
 ---
 
@@ -307,6 +327,9 @@ Cloudflare Workers の `scheduled` ハンドラを Ruby 側から書けるよう
 | シンタックスハイライタ (rouge) | クライアント側で highlight.js / shiki で十分 |
 | ActiveRecord | D1 用 adapter を書く工数 vs リターンが見合わない（Sequel の方がまだ筋が良いが Phase 11 以降） |
 | Nokogiri | libxml2 ネイティブ依存で物理的に不可 |
+| Llama 系モデル全般 | マスター指示により意図的不採用（Phase 10） |
+| RSA-PKCS1 v1.5 encrypt | subtle が OAEP のみ提供、OAEP がモダン推奨（Phase 7） |
+| ChaCha20-Poly1305 | Web Crypto 標準にも nodejs_compat にもなし、pure-JS 必要（Phase 7 で確認、Phase 11 候補） |
 
 → **判断基準**: 「Worker（=サーバー側）でしかできないか？シークレット・永続化・
 AI 等の境界に絡むか？」を Yes と言えるものだけ採用。


### PR DESCRIPTION
## Summary

Update `docs/ROADMAP.md` to reflect what's actually shipped and refine the upcoming Phases.

- Mark **Phase 6** (HTTP fetch shim) and **Phase 7** (full crypto suite) as ✅ shipped, with concrete commit references (\`48c37a7\` / \`4f53fa1\`, PR #1 / PR #2).
- Refine **Phase 8** (JWT auth) based on what Phase 7 actually delivered: with HS/RS/PS/ES/EdDSA primitives in place, the jwt gem only needs a thin \`.__await__\` patch on sign/verify call sites — the algorithm matrix is covered out of the box.
- **Phase 9** (Cron) / **Phase 10** (Workers AI, Gemma 4) — scope unchanged.
- **Phase 11** candidate table expanded: Vectorize, Durable Objects, Queues, Cache API, Email Workers, Service Bindings, ChaCha20-Poly1305 (pure-JS), multipart, Faraday, JWE.
- New process rules:
  - 「妥協は禁止」 — implement everything; only skip on physically verified platform constraints (no guessing)
  - Workers self-test mandatory — every Phase must add an in-Worker verification endpoint, not just Node tests
- "Unadopted" table grows: RSA-PKCS1 v1.5 encrypt and ChaCha20-Poly1305 with verified reasons

## Test plan

- [x] Markdown renders correctly (no broken table syntax)
- [x] No code changes; pure documentation
- [x] References to PR #1 / PR #2 are stable

## Notes

- This PR depends on PR #2 (Phase 7 code) being merged for the Phase 7 ✅ entry to be technically accurate, but the doc itself doesn't change code.
- README updates for Phase 7 are intentionally not in this PR — they live in PR #2 to avoid duplicating the "Crypto works (Phase 7)" section across two branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)