### PR TITLE
Phase 10 — Workers AI binding + Sinatra /chat demo (Gemma 4 + gpt-oss-120b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,76 @@
 
 Live demo: **<https://homurabi.kazu-san.workers.dev>**
 
+---
+
+## Phase 10 hero — Sinatra `/chat` × Workers AI (Gemma 4 + gpt-oss-120b)
+
+A real Sinatra route, hosted on Cloudflare Workers, talking to **Cloudflare
+Workers AI** through the `env.AI` binding — wrapped in a tiny Ruby helper so
+the route reads like any other Sinatra controller. JWT-protected via the
+Phase 8 vendored `ruby-jwt`. Conversation history persists in **Workers KV**.
+
+```ruby
+# app/hello.rb (excerpt)
+CHAT_MODELS = {
+  primary:  '@cf/google/gemma-4-26b-a4b-it',  # Google Gemma 4, 256K ctx, $0.10/$0.30 per Mtok
+  fallback: '@cf/openai/gpt-oss-120b'         # OpenAI gpt-oss-120b, 128K ctx, $0.35/$0.75 per Mtok
+}.freeze
+
+post '/api/chat/messages' do
+  content_type 'application/json'
+  # ... inline JWT verify (see source) ...
+  history = load_chat_history(session_id).__await__
+  result  = Cloudflare::AI.run(
+              model,
+              { messages: build_ai_messages(history, user_text), max_tokens: 1024 },
+              binding: env['cloudflare.AI']
+            ).__await__
+  reply_text = App.extract_ai_text(result).strip
+  save_chat_history(session_id, history + [...]).__await__
+  { 'ok' => true, 'reply' => reply_text, 'model' => model, 'history_len' => ... }.to_json
+end
+```
+
+```text
+# Live capture (wrangler dev → real Workers AI; full log: .artifacts/phase10-ai/api-evidence.txt)
+$ TOKEN=$(curl -s -X POST 'http://127.0.0.1:8788/api/login?alg=HS256' \
+            -H 'content-type: application/json' \
+            -d '{"username":"chat-demo","role":"user"}' | jq -r .access_token)
+
+$ curl -s -X POST 'http://127.0.0.1:8788/api/chat/messages' \
+       -H "authorization: Bearer $TOKEN" \
+       -H 'content-type: application/json' \
+       -d '{"session":"hero","content":"日本語で50字以内で挨拶＋自己紹介",
+            "model":"@cf/google/gemma-4-26b-a4b-it"}' | jq
+{
+  "ok": true,
+  "session": "hero",
+  "model": "@cf/google/gemma-4-26b-a4b-it",
+  "used_fallback": false,
+  "elapsed_ms": 3112,
+  "reply": "こんにちは！homurabiです。Sinatra-on-Cloudflare-Workersのフレンドリーな助手です。",
+  "history_len": 2
+}
+```
+
+| binding | what we use | model |
+|---|---|---|
+| `env.AI` | text generation, OpenAI-compatible chat completions | **`@cf/google/gemma-4-26b-a4b-it`** (primary) · `@cf/openai/gpt-oss-120b` (fallback) |
+| `env.KV` | per-session chat history (`chat:<session>`, capped at 32 messages) | n/a |
+| Phase 8 JWT | inline verify against `Authorization: Bearer …` (HS256 by default) | n/a |
+
+The chat UI lives at `GET /chat` (`views/chat.erb` precompiled by `bin/compile-erb`).
+`POST /api/chat/messages`, `GET /api/chat/messages`, `DELETE /api/chat/messages`
+are JWT-gated. `/test/ai` runs both models against the live Workers AI catalog
+as a "CI on Workers" smoke check; `/test/ai/debug` dumps the raw Workers AI
+response so you can spot model-specific schema drift.
+
+> **Llama-family models intentionally excluded.** Phase 10 ships Gemma 4 +
+> gpt-oss-120b only; see `docs/ROADMAP.md` for the rationale.
+
+---
+
 ```ruby
 # app/hello.rb — literal Sinatra DSL, no Cloudflare imports, no backtick JS.
 require 'sinatra/base'

--- a/app/hello.rb
+++ b/app/hello.rb
@@ -753,6 +753,483 @@ class App < Sinatra::Base
       }
     }.to_json
   end
+
+  # ------------------------------------------------------------------
+  # Phase 10 — Workers AI chat demo.
+  #
+  # Sinatra routes call Cloudflare::AI.run(model, inputs, binding: ai)
+  # to invoke a Workers AI model. The chat UI lives at GET /chat,
+  # API endpoints under /api/chat/*.
+  #
+  # Models are pinned at the top of the chat block so swapping the
+  # primary or adding more fallbacks is one constant edit. Llama-family
+  # models are intentionally excluded per Phase 10 master directive.
+  # ------------------------------------------------------------------
+  CHAT_MODELS = {
+    primary:  '@cf/google/gemma-4-26b-a4b-it',
+    fallback: '@cf/openai/gpt-oss-120b'
+  }.freeze
+  CHAT_HISTORY_LIMIT = 32       # last N messages kept in KV per session
+  CHAT_HISTORY_TTL   = 86_400 * 7  # 1 week
+  CHAT_SYSTEM_PROMPT = 'You are homurabi, a friendly Sinatra-on-Cloudflare-Workers assistant. Reply concisely. If the user writes Japanese, reply in Japanese. If the user writes English, reply in English.'
+
+  # Workers AI returns one of two response shapes depending on the model:
+  # 1. legacy `{ response: "..." }`            (e.g. older llama, mistral)
+  # 2. OpenAI-style `{ choices: [{ message: { content: "..." } }] }`
+  #    (Gemma 4, gpt-oss-* and any other "chat completions"-shaped model)
+  # Helper that tolerates both so the route doesn't have to branch.
+  def self.extract_ai_text(out)
+    return out.to_s unless out.is_a?(Hash)
+    # OpenAI-style choices[].message.content
+    if out['choices'].is_a?(Array) && !out['choices'].empty?
+      msg = out['choices'][0].is_a?(Hash) ? out['choices'][0]['message'] : nil
+      if msg.is_a?(Hash)
+        c = msg['content']
+        return c.to_s if c.is_a?(String) && !c.empty?
+        # Some models put the visible answer in `reasoning` when the
+        # response is truncated by max_tokens. Surface it as a fallback
+        # so the user still sees something useful.
+        r = msg['reasoning']
+        return r.to_s if r.is_a?(String) && !r.empty?
+      end
+    end
+    # Legacy `{ response: "..." }` / generic fallbacks.
+    %w[response result output text].each do |k|
+      v = out[k]
+      return v.to_s if v.is_a?(String) && !v.empty?
+    end
+    ''
+  end
+
+  helpers do
+    def ai_demos_enabled?
+      cf_env = env['cloudflare.env']
+      return false unless cf_env
+      val = `(#{cf_env} && #{cf_env}.HOMURABI_ENABLE_AI_DEMOS) || ''`
+      val.to_s == '1'
+    end
+
+    def ai_binding
+      env['cloudflare.AI']
+    end
+
+    # JS-aware "is the binding present?" — env.AI is a raw JS object
+    # without a Ruby `.nil?` method, so `binding.nil?` would explode at
+    # runtime. This helper checks the JS-level null/undefined directly.
+    def ai_binding?
+      v = env['cloudflare.AI']
+      `(#{v} != null)`
+    end
+
+    # JSON body parse with a graceful default.
+    def parse_json_body
+      raw = request.body.read.to_s
+      return {} if raw.empty?
+      JSON.parse(raw)
+    rescue JSON::ParserError, StandardError
+      {}
+    end
+
+    def chat_kv_key(session_id)
+      "chat:#{session_id}"
+    end
+
+    # Returns the array of {role, content} message Hashes for a session,
+    # or [] if KV has nothing (or no KV is bound).
+    def load_chat_history(session_id)
+      return [] unless kv
+      raw = kv.get(chat_kv_key(session_id)).__await__
+      return [] if raw.nil? || raw.empty?
+      arr = JSON.parse(raw)
+      arr.is_a?(Array) ? arr : []
+    rescue JSON::ParserError
+      []
+    end
+
+    def save_chat_history(session_id, history)
+      return unless kv
+      trimmed = history.last(CHAT_HISTORY_LIMIT)
+      kv.put(chat_kv_key(session_id), trimmed.to_json).__await__
+    end
+
+    def clear_chat_history(session_id)
+      return unless kv
+      kv.delete(chat_kv_key(session_id)).__await__
+    end
+
+    # Convert chat history to the messages array Workers AI expects.
+    # Always prepends a system prompt so the model has consistent persona.
+    def build_ai_messages(history, latest_user_text)
+      msgs = [{ 'role' => 'system', 'content' => CHAT_SYSTEM_PROMPT }]
+      history.each { |m| msgs << { 'role' => m['role'], 'content' => m['content'] } }
+      msgs << { 'role' => 'user', 'content' => latest_user_text }
+      msgs
+    end
+
+    # Halt with the right error JSON if the AI demo is gated off.
+    def require_ai_demos!
+      unless ai_demos_enabled?
+        content_type 'application/json'
+        halt 404, { 'error' => 'AI demos disabled (set HOMURABI_ENABLE_AI_DEMOS=1 in wrangler vars)' }.to_json
+      end
+    end
+
+    def require_ai_binding!
+      unless ai_binding?
+        content_type 'application/json'
+        halt 503, { 'error' => 'AI binding not configured (wrangler.toml [ai] block missing or wrangler version too old)' }.to_json
+      end
+    end
+
+    # Inline JWT verification tailored for the chat routes.
+    #
+    # Sinatra's `Sinatra::JwtAuth#authenticate!` helper relies on `halt`,
+    # which is implemented via `throw :halt`. When the helper itself is
+    # `# await: true` (because JWT.decode awaits Web Crypto subtle), the
+    # `throw` escapes the async boundary before Sinatra's
+    # `catch :halt do ... end` wrapper can see it, and the route crashes
+    # with `UncaughtThrowError: "halt"`. Same root cause as the
+    # `each: undefined method for PromiseV2` issue — async Sinatra needs
+    # values, not control-flow exceptions, across the await boundary.
+    #
+    # `chat_verify_token!` returns either:
+    #   - a Hash with `{ ok: true, payload: <decoded> }` on success, or
+    #   - a Hash with `{ ok: false, status: 401, body: <json> }` on
+    #     failure (so the route can `next body` after a status set).
+    # The route is responsible for halting / returning early.
+    def chat_verify_token!
+      header = request.env['HTTP_AUTHORIZATION'].to_s
+      parts = header.split(' ', 2)
+      if parts.length != 2 || parts[0].downcase != 'bearer'
+        return { 'ok' => false, 'status' => 401,
+                 'body' => { 'error' => 'unauthorized', 'reason' => 'missing bearer token' }.to_json }
+      end
+      token = parts[1].strip
+      if token.empty?
+        return { 'ok' => false, 'status' => 401,
+                 'body' => { 'error' => 'unauthorized', 'reason' => 'missing bearer token' }.to_json }
+      end
+      verify_key = settings.jwt_secret
+      algorithm  = settings.jwt_algorithm
+      reason = nil
+      decoded = begin
+        JWT.decode(token, verify_key, true, algorithm: algorithm).__await__
+      rescue JWT::ExpiredSignature
+        reason = 'token expired'
+        nil
+      rescue JWT::VerificationError
+        reason = 'signature verification failed'
+        nil
+      rescue JWT::IncorrectAlgorithm
+        reason = 'algorithm mismatch'
+        nil
+      rescue JWT::DecodeError => e
+        reason = "invalid token: #{e.message}"
+        nil
+      rescue StandardError => e
+        reason = "auth error: #{e.message}"
+        nil
+      end
+      if decoded.nil?
+        return { 'ok' => false, 'status' => 401,
+                 'body' => { 'error' => 'unauthorized', 'reason' => reason || 'token verification failed' }.to_json }
+      end
+      payload, _header = decoded
+      @jwt_payload = payload
+      { 'ok' => true, 'payload' => payload }
+    end
+  end
+
+  # GET /chat — chat UI page. JWT-gated for API calls (the page itself
+  # is open so the user can mint a token from inside it).
+  get '/chat' do
+    @title = 'homurabi /chat — Workers AI'
+    @primary_model  = CHAT_MODELS[:primary]
+    @fallback_model = CHAT_MODELS[:fallback]
+    @session_id = (params['session'] && !params['session'].to_s.empty?) ? params['session'] : 'demo'
+    @history = ai_demos_enabled? ? load_chat_history(@session_id).__await__ : []
+    @content = erb :chat
+    erb :layout
+  end
+
+  # GET /api/chat/health — lightweight binding check; no AI call.
+  get '/api/chat/health' do
+    content_type 'application/json'
+    {
+      'ok'             => true,
+      'demos_enabled'  => ai_demos_enabled?,
+      'ai_bound'       => ai_binding?,
+      'kv_bound'       => !kv.nil?,
+      'primary_model'  => CHAT_MODELS[:primary],
+      'fallback_model' => CHAT_MODELS[:fallback]
+    }.to_json
+  end
+
+  # POST /api/chat/messages — append a user message, call Workers AI,
+  # persist the round-trip in KV, and return the assistant reply.
+  # Body: { "session": "...", "content": "...", "model": "@cf/.../...?" }
+  post '/api/chat/messages' do
+    content_type 'application/json'
+    require_ai_demos!
+    # Inline JWT verification — early-exit with explicit `status` and
+    # `next` (the same pattern Phase 8's /api/me uses successfully).
+    # We deliberately do NOT call `Sinatra::JwtAuth#authenticate!`
+    # because that helper uses `halt` which throws past Opal's async
+    # boundary (Sinatra's `catch :halt` cannot see a JS Promise
+    # rejection). And we keep the token decode outside any helper so
+    # the `status N` call sits in the same `dispatch!` frame as the
+    # `next` — pulling it into a helper made the response leak out
+    # as 200 in earlier iterations.
+    auth_header = request.env['HTTP_AUTHORIZATION'].to_s
+    parts = auth_header.split(' ', 2)
+    if parts.length != 2 || parts[0].downcase != 'bearer'
+      status 401
+      next({ 'error' => 'unauthorized', 'reason' => 'missing bearer token' }.to_json)
+    end
+    auth_token = parts[1].strip
+    if auth_token.empty?
+      status 401
+      next({ 'error' => 'unauthorized', 'reason' => 'missing bearer token' }.to_json)
+    end
+    # JWT verify (post-await). Setting `status N` after the await would
+    # not take effect because Sinatra's `invoke` snapshots
+    # `response.status` synchronously when it sees a Promise body, so
+    # any mutation that happens later than that snapshot is lost. We
+    # work around it by returning `[status, body]` from the route — the
+    # homurabi patch in `build_js_response` detects that single-chunk
+    # shape and uses the embedded status when constructing the JS
+    # Response.
+    decode_err = `(async function(){
+      try {
+        await #{JWT.decode(auth_token, settings.jwt_secret, true, algorithm: settings.jwt_algorithm)};
+        return null;
+      } catch (e) {
+        var msg = (e && e.$message) ? e.$message() : (e && e.message) ? e.message : String(e);
+        return 'invalid token: ' + String(msg);
+      }
+    })()`.__await__
+    is_failure = `(#{decode_err} != null && #{decode_err} !== undefined)`
+    if is_failure
+      err_msg = decode_err.to_s
+      next [401, { 'error' => 'unauthorized', 'reason' => err_msg }.to_json]
+    end
+    require_ai_binding!
+
+    body = parse_json_body
+    session_id = body['session'].to_s
+    session_id = 'demo' if session_id.empty?
+    user_text  = body['content'].to_s
+    if user_text.strip.empty?
+      status 400
+      next({ 'error' => 'content required' }.to_json)
+    end
+
+    requested_model = body['model'].to_s
+    primary  = CHAT_MODELS[:primary]
+    fallback = CHAT_MODELS[:fallback]
+    # Allow either of the two configured models. Anything else is
+    # rejected so a client can't run up neuron costs on arbitrary models.
+    model = if requested_model == primary || requested_model == fallback
+              requested_model
+            else
+              primary
+            end
+
+    # Helper methods that internally call `__await__` on a binding
+    # (KV / D1 / AI) compile to async JS functions, so each helper
+    # call must be `__await__`'d at the call site to unwrap the
+    # returned Promise. Without the explicit await, `history` would
+    # be a PromiseV2 and downstream `JSON.parse` / Array iteration
+    # would crash with "undefined method `each` for PromiseV2".
+    history = load_chat_history(session_id).__await__
+    messages = build_ai_messages(history, user_text)
+
+    started_at = Time.now.to_f
+    used_model = model
+    used_fallback = false
+    reply_text = nil
+    ai_error  = nil
+
+    begin
+      result = Cloudflare::AI.run(
+        model,
+        # max_tokens raised to 1024 because OpenAI-style models (Gemma 4,
+        # gpt-oss-*) report `finish_reason: "length"` and surface the
+        # visible answer in `message.reasoning` instead of `content` when
+        # truncated. 1024 is generous enough for most chat replies and
+        # still well under Workers' 30s wall-time budget.
+        { messages: messages, max_tokens: 1024 },
+        binding: ai_binding
+      ).__await__
+      reply_text = App.extract_ai_text(result).strip
+      raise Cloudflare::AIError.new('empty response', model: model) if reply_text.empty?
+    rescue Cloudflare::AIError => e
+      ai_error = e
+    end
+
+    # Fallback: if the primary model fails or returns empty, retry with
+    # the secondary model exactly once before surfacing an error.
+    if reply_text.nil? || reply_text.empty?
+      used_fallback = true
+      used_model = (model == primary) ? fallback : primary
+      begin
+        result = Cloudflare::AI.run(
+          used_model,
+          { messages: messages, max_tokens: 1024 },
+          binding: ai_binding
+        ).__await__
+        reply_text = App.extract_ai_text(result).strip
+      rescue Cloudflare::AIError => e
+        status 502
+        next({ 'error' => 'workers AI call failed', 'detail' => e.message, 'fallback_error' => true }.to_json)
+      end
+      if reply_text.nil? || reply_text.empty?
+        status 502
+        next({ 'error' => 'workers AI returned empty response on both primary and fallback' }.to_json)
+      end
+    end
+
+    elapsed_ms = ((Time.now.to_f - started_at) * 1000).to_i
+    new_history = history + [
+      { 'role' => 'user',      'content' => user_text },
+      { 'role' => 'assistant', 'content' => reply_text }
+    ]
+    save_chat_history(session_id, new_history).__await__
+
+    {
+      'ok'           => true,
+      'session'      => session_id,
+      'model'        => used_model,
+      'used_fallback'=> used_fallback,
+      'elapsed_ms'   => elapsed_ms,
+      'reply'        => reply_text,
+      'history_len'  => new_history.size
+    }.to_json
+  end
+
+  # GET /api/chat/messages — return the persisted history for a session.
+  get '/api/chat/messages' do
+    content_type 'application/json'
+    require_ai_demos!
+    auth = chat_verify_token!.__await__
+    if auth['ok'] != true
+      # See the long comment in POST /api/chat/messages for why we
+      # return [status, body] instead of using `status N; next body`
+      # — Sinatra snapshots response.status before the await resolves,
+      # so any later mutation is lost.
+      next [auth['status'].to_i, auth['body']]
+    end
+    session_id = (params['session'] && !params['session'].to_s.empty?) ? params['session'] : 'demo'
+    {
+      'session' => session_id,
+      'history' => load_chat_history(session_id).__await__
+    }.to_json
+  end
+
+  # DELETE /api/chat/messages?session=... — wipe history for a session.
+  delete '/api/chat/messages' do
+    content_type 'application/json'
+    require_ai_demos!
+    auth = chat_verify_token!.__await__
+    if auth['ok'] != true
+      # See the long comment in POST /api/chat/messages for why we
+      # return [status, body] instead of using `status N; next body`
+      # — Sinatra snapshots response.status before the await resolves,
+      # so any later mutation is lost.
+      next [auth['status'].to_i, auth['body']]
+    end
+    session_id = (params['session'] && !params['session'].to_s.empty?) ? params['session'] : 'demo'
+    clear_chat_history(session_id).__await__
+    { 'ok' => true, 'session' => session_id, 'cleared' => true }.to_json
+  end
+
+  # GET /test/ai/debug — dump the raw AI binding response so we can see
+  # what shape Workers AI actually returns. Useful when adding support
+  # for a new model whose `extract_ai_text` mapping isn't obvious.
+  get '/test/ai/debug' do
+    content_type 'application/json'
+    unless ai_demos_enabled? && ai_binding?
+      status 404
+      next({ 'error' => 'disabled' }.to_json)
+    end
+    model = params['model'] || CHAT_MODELS[:primary]
+    out = Cloudflare::AI.run(
+      model,
+      { messages: [
+        { role: 'system', content: 'reply with a short Japanese greeting' },
+        { role: 'user',   content: 'こんにちは' }
+      ], max_tokens: 64 },
+      binding: ai_binding
+    ).__await__
+    {
+      'model'    => model,
+      'class'    => out.class.to_s,
+      'is_hash'  => out.is_a?(Hash),
+      'keys'     => out.is_a?(Hash) ? out.keys : nil,
+      'extracted'=> App.extract_ai_text(out),
+      'raw'      => out
+    }.to_json
+  end
+
+  # GET /test/ai — Workers self-test for the AI binding. Exercises the
+  # primary model with a trivial prompt and reports pass/fail. Gated
+  # behind the same HOMURABI_ENABLE_AI_DEMOS flag so it can't be hit
+  # accidentally in production.
+  get '/test/ai' do
+    content_type 'application/json'
+    unless ai_demos_enabled?
+      status 404
+      next({ 'error' => 'AI demos disabled (set HOMURABI_ENABLE_AI_DEMOS=1)' }.to_json)
+    end
+    unless ai_binding?
+      status 503
+      next({ 'error' => 'AI binding not bound (wrangler.toml [ai] block missing)' }.to_json)
+    end
+
+    cases = []
+    primary  = CHAT_MODELS[:primary]
+    fallback = CHAT_MODELS[:fallback]
+
+    # NOTE: blocks-with-`__await__` compile to async functions in Opal
+    # under `# await: true`. Iterators like `Array#each_with_index`
+    # don't await each step, so any work the block kicks off races
+    # against the JSON serialisation below — the route would return
+    # `{cases: []}` before the AI call even finished. Inline a manual
+    # loop where each step is followed by an explicit `__await__`.
+
+    test_one = lambda { |model, label|
+      result = begin
+        out = Cloudflare::AI.run(model,
+          { messages: [
+            { role: 'system', content: 'reply with the single word READY' },
+            { role: 'user',   content: 'ping' }
+          ], max_tokens: 64 },
+          binding: ai_binding
+        ).__await__
+        txt = App.extract_ai_text(out).strip
+        if txt.empty?
+          { 'pass' => false, 'note' => 'empty response from model' }
+        else
+          { 'pass' => true, 'note' => txt[0, 200] }
+        end
+      rescue ::Exception => e
+        { 'pass' => false, 'note' => "#{e.class}: #{e.message[0, 200]}" }
+      end
+      result.merge('case' => label)
+    }
+
+    cases << test_one.call(primary,  "primary model #{primary} responds").__await__
+    cases << test_one.call(fallback, "fallback model #{fallback} responds").__await__
+
+    passed = cases.count { |c| c['pass'] }
+    failed = cases.size - passed
+    {
+      'passed' => passed,
+      'failed' => failed,
+      'total'  => cases.size,
+      'cases'  => cases
+    }.to_json
+  end
 end
 
 run App

--- a/app/hello.rb
+++ b/app/hello.rb
@@ -830,6 +830,19 @@ class App < Sinatra::Base
       {}
     end
 
+    # Allow only `[A-Za-z0-9_-]{1,64}` for session ids so a crafted
+    # `?session=` cannot inject HTML when echoed back to /chat, cannot
+    # generate exotic KV key names (which would also escape `chat:` and
+    # collide with other namespaces), and cannot create unbounded
+    # per-user key cardinality. Falls back to `'demo'` on rejection.
+    SESSION_ID_RE = /\A[A-Za-z0-9_-]{1,64}\z/.freeze
+
+    def normalize_session_id(raw)
+      s = raw.to_s
+      return 'demo' if s.empty?
+      SESSION_ID_RE.match?(s) ? s : 'demo'
+    end
+
     def chat_kv_key(session_id)
       "chat:#{session_id}"
     end
@@ -849,7 +862,11 @@ class App < Sinatra::Base
     def save_chat_history(session_id, history)
       return unless kv
       trimmed = history.last(CHAT_HISTORY_LIMIT)
-      kv.put(chat_kv_key(session_id), trimmed.to_json).__await__
+      # Pass CHAT_HISTORY_TTL through so KV expires the entry
+      # automatically and the namespace doesn't accumulate dead
+      # sessions forever (the constant was previously documented but
+      # unused — Copilot review #5).
+      kv.put(chat_kv_key(session_id), trimmed.to_json, expiration_ttl: CHAT_HISTORY_TTL).__await__
     end
 
     def clear_chat_history(session_id)
@@ -866,19 +883,21 @@ class App < Sinatra::Base
       msgs
     end
 
-    # Halt with the right error JSON if the AI demo is gated off.
-    def require_ai_demos!
-      unless ai_demos_enabled?
-        content_type 'application/json'
-        halt 404, { 'error' => 'AI demos disabled (set HOMURABI_ENABLE_AI_DEMOS=1 in wrangler vars)' }.to_json
-      end
+    # Both gates return either nil (= keep going) or a `[status, body]`
+    # tuple that the caller hands back via `next`. We deliberately do
+    # NOT use `halt` because the chat routes are `# await: true` async
+    # blocks; `halt` is implemented as `throw :halt`, and the throw
+    # escapes Sinatra's synchronous `catch :halt` wrapper through the
+    # async/await boundary (Copilot review #8/#9). Same root cause as
+    # the JWT auth helper rewrite.
+    def ai_demos_block_or_nil
+      return nil if ai_demos_enabled?
+      [404, { 'error' => 'AI demos disabled (set HOMURABI_ENABLE_AI_DEMOS=1 in wrangler vars)' }.to_json]
     end
 
-    def require_ai_binding!
-      unless ai_binding?
-        content_type 'application/json'
-        halt 503, { 'error' => 'AI binding not configured (wrangler.toml [ai] block missing or wrangler version too old)' }.to_json
-      end
+    def ai_binding_block_or_nil
+      return nil if ai_binding?
+      [503, { 'error' => 'AI binding not configured (wrangler.toml [ai] block missing or wrangler version too old)' }.to_json]
     end
 
     # Inline JWT verification tailored for the chat routes.
@@ -946,7 +965,7 @@ class App < Sinatra::Base
     @title = 'homurabi /chat — Workers AI'
     @primary_model  = CHAT_MODELS[:primary]
     @fallback_model = CHAT_MODELS[:fallback]
-    @session_id = (params['session'] && !params['session'].to_s.empty?) ? params['session'] : 'demo'
+    @session_id = normalize_session_id(params['session'])
     @history = ai_demos_enabled? ? load_chat_history(@session_id).__await__ : []
     @content = erb :chat
     erb :layout
@@ -970,7 +989,8 @@ class App < Sinatra::Base
   # Body: { "session": "...", "content": "...", "model": "@cf/.../...?" }
   post '/api/chat/messages' do
     content_type 'application/json'
-    require_ai_demos!
+    gate = ai_demos_block_or_nil
+    next gate if gate
     # Inline JWT verification — early-exit with explicit `status` and
     # `next` (the same pattern Phase 8's /api/me uses successfully).
     # We deliberately do NOT call `Sinatra::JwtAuth#authenticate!`
@@ -1013,11 +1033,11 @@ class App < Sinatra::Base
       err_msg = decode_err.to_s
       next [401, { 'error' => 'unauthorized', 'reason' => err_msg }.to_json]
     end
-    require_ai_binding!
+    bgate = ai_binding_block_or_nil
+    next bgate if bgate
 
     body = parse_json_body
-    session_id = body['session'].to_s
-    session_id = 'demo' if session_id.empty?
+    session_id = normalize_session_id(body['session'])
     user_text  = body['content'].to_s
     if user_text.strip.empty?
       status 400
@@ -1110,7 +1130,8 @@ class App < Sinatra::Base
   # GET /api/chat/messages — return the persisted history for a session.
   get '/api/chat/messages' do
     content_type 'application/json'
-    require_ai_demos!
+    gate = ai_demos_block_or_nil
+    next gate if gate
     auth = chat_verify_token!.__await__
     if auth['ok'] != true
       # See the long comment in POST /api/chat/messages for why we
@@ -1119,7 +1140,7 @@ class App < Sinatra::Base
       # so any later mutation is lost.
       next [auth['status'].to_i, auth['body']]
     end
-    session_id = (params['session'] && !params['session'].to_s.empty?) ? params['session'] : 'demo'
+    session_id = normalize_session_id(params['session'])
     {
       'session' => session_id,
       'history' => load_chat_history(session_id).__await__
@@ -1129,7 +1150,8 @@ class App < Sinatra::Base
   # DELETE /api/chat/messages?session=... — wipe history for a session.
   delete '/api/chat/messages' do
     content_type 'application/json'
-    require_ai_demos!
+    gate = ai_demos_block_or_nil
+    next gate if gate
     auth = chat_verify_token!.__await__
     if auth['ok'] != true
       # See the long comment in POST /api/chat/messages for why we
@@ -1138,7 +1160,7 @@ class App < Sinatra::Base
       # so any later mutation is lost.
       next [auth['status'].to_i, auth['body']]
     end
-    session_id = (params['session'] && !params['session'].to_s.empty?) ? params['session'] : 'demo'
+    session_id = normalize_session_id(params['session'])
     clear_chat_history(session_id).__await__
     { 'ok' => true, 'session' => session_id, 'cleared' => true }.to_json
   end

--- a/lib/cloudflare_workers.rb
+++ b/lib/cloudflare_workers.rb
@@ -207,9 +207,16 @@ module Rack
           js_db = `#{js_env} && #{js_env}.DB`
           js_kv = `#{js_env} && #{js_env}.KV`
           js_r2 = `#{js_env} && #{js_env}.BUCKET`
+          js_ai = `#{js_env} && #{js_env}.AI`
           env['cloudflare.DB']     = Cloudflare::D1Database.new(js_db)  if `#{js_db} != null`
           env['cloudflare.KV']     = Cloudflare::KVNamespace.new(js_kv) if `#{js_kv} != null`
           env['cloudflare.BUCKET'] = Cloudflare::R2Bucket.new(js_r2)    if `#{js_r2} != null`
+          # Phase 10: env.AI is a Workers AI binding object. Routes call
+          # Cloudflare::AI.run(model, inputs, binding: env['cloudflare.AI'])
+          # to invoke a model. We expose the raw JS object (not a wrapper)
+          # because the wrapper is stateless — every call passes both the
+          # model id and the binding explicitly.
+          env['cloudflare.AI']     = js_ai if `#{js_ai} != null`
 
           env
         end
@@ -259,6 +266,26 @@ module Rack
             return `new Response(#{js_stream}, { status: #{status.to_i}, headers: #{js_headers} })`
           end
 
+          # Phase 10 — Workers AI streaming: a Cloudflare::AI::Stream wraps
+          # a JS ReadableStream<Uint8Array> emitting SSE-formatted bytes
+          # ("data: {json}\n\n"). Pass it straight through so the client
+          # receives the chunks as they arrive.
+          stream_obj = nil
+          if body.respond_to?(:sse_stream?) && body.sse_stream?
+            stream_obj = body
+          elsif body.respond_to?(:first) && body.first.respond_to?(:sse_stream?) && body.first.sse_stream?
+            stream_obj = body.first
+          end
+          if stream_obj
+            js_stream = stream_obj.js_stream
+            js_headers = `({})`
+            headers.each { |k, v| ks = k.to_s; vs = v.to_s; `#{js_headers}[#{ks}] = #{vs}` }
+            `#{js_headers}['content-type'] = 'text/event-stream; charset=utf-8'`
+            `#{js_headers}['cache-control'] = 'no-cache, no-transform'`
+            `#{js_headers}['x-accel-buffering'] = 'no'`
+            return `new Response(#{js_stream}, { status: #{status.to_i}, headers: #{js_headers} })`
+          end
+
           chunks = []
           if body.respond_to?(:each)
             body.each { |chunk| chunks << chunk }
@@ -283,7 +310,11 @@ module Rack
           end
 
           if has_promise
-            `Promise.all(#{js_chunks}).then(function(resolved) { for (var i = 0; i < resolved.length; i++) { var r = resolved[i]; if (r != null && r.stream != null && r.content_type != null) { var bh = {}; bh['content-type'] = r.content_type; if (r.cache_control) bh['cache-control'] = r.cache_control; return new Response(r.stream, { status: #{status_int}, headers: bh }); } } var parts = []; for (var i = 0; i < resolved.length; i++) { var r = resolved[i]; if (r == null) { parts.push(''); continue; } if (typeof r === 'string') { parts.push(r); continue; } if (r != null && r.$$is_string) { parts.push(r.toString()); continue; } try { parts.push(JSON.stringify(r)); } catch (e) { parts.push(String(r)); } } return new Response(parts.join(''), { status: #{status_int}, headers: #{js_headers} }); })`
+            # Phase 10 patch: route may return [status, body] from a
+            # post-await branch so it can express a non-200 status the
+            # async-promise path of Sinatra::Base#invoke would otherwise
+            # snapshot away. Single-line x-string per the file convention.
+            `Promise.all(#{js_chunks}).then(function(resolved) { for (var i = 0; i < resolved.length; i++) { var r = resolved[i]; if (r != null && r.stream != null && r.content_type != null) { var bh = {}; bh['content-type'] = r.content_type; if (r.cache_control) bh['cache-control'] = r.cache_control; return new Response(r.stream, { status: #{status_int}, headers: bh }); } } if (resolved.length === 1 && resolved[0] != null && Array.isArray(resolved[0]) && resolved[0].length === 2 && typeof resolved[0][0] === 'number') { var ov = resolved[0]; var ovs = ov[0]|0; var ovb = ov[1] == null ? '' : (typeof ov[1] === 'string' ? ov[1] : (ov[1].$$is_string ? ov[1].toString() : String(ov[1]))); return new Response(ovb, { status: ovs, headers: #{js_headers} }); } var parts = []; for (var i = 0; i < resolved.length; i++) { var r = resolved[i]; if (r == null) { parts.push(''); continue; } if (typeof r === 'string') { parts.push(r); continue; } if (r != null && r.$$is_string) { parts.push(r.toString()); continue; } try { parts.push(JSON.stringify(r)); } catch (e) { parts.push(String(r)); } } return new Response(parts.join(''), { status: #{status_int}, headers: #{js_headers} }); })`
           else
             body_str = ''
             chunks.each { |c| body_str = body_str + c.to_s }
@@ -602,3 +633,7 @@ end
 # Workers adapter so user code can simply `require 'sinatra/base'`
 # and use Net::HTTP / Cloudflare::HTTP.fetch without an extra require.
 require 'cloudflare_workers/http'
+
+# Phase 10 — Workers AI binding wrapper. Loaded here so any Sinatra
+# route can call Cloudflare::AI.run(...) without an extra require.
+require 'cloudflare_workers/ai'

--- a/lib/cloudflare_workers.rb
+++ b/lib/cloudflare_workers.rb
@@ -569,11 +569,19 @@ module Cloudflare
       `#{js_kv}.get(#{key}, "text").then(function(v) { return v == null ? nil : v; }).catch(function(e) { #{Kernel}.$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'KV', operation: 'get'}))); })`
     end
 
-    # Put a value. Returns a JS Promise.
-    def put(key, value)
+    # Put a value. `expiration_ttl:` (seconds) maps to the Workers KV
+    # `expirationTtl` option so callers can set TTLs without reaching
+    # for backticks. Returns a JS Promise.
+    def put(key, value, expiration_ttl: nil)
       js_kv = @js
       err_cls = Cloudflare::KVError
-      `#{js_kv}.put(#{key}, #{value}).catch(function(e) { #{Kernel}.$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'KV', operation: 'put'}))); })`
+      ttl = expiration_ttl
+      if ttl.nil?
+        `#{js_kv}.put(#{key}, #{value}).catch(function(e) { #{Kernel}.$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'KV', operation: 'put'}))); })`
+      else
+        ttl_int = ttl.to_i
+        `#{js_kv}.put(#{key}, #{value}, { expirationTtl: #{ttl_int} }).catch(function(e) { #{Kernel}.$raise(#{err_cls}.$new(e.message || String(e), Opal.hash({binding_type: 'KV', operation: 'put'}))); })`
+      end
     end
 
     # Delete a key. Returns a JS Promise.

--- a/lib/cloudflare_workers/ai.rb
+++ b/lib/cloudflare_workers/ai.rb
@@ -58,7 +58,12 @@ module Cloudflare
       ai_binding = binding
       err_klass = Cloudflare::AIError
       stream_klass = Cloudflare::AI::Stream
-      streaming = inputs.is_a?(Hash) && (inputs[:stream] == true || inputs['stream'] == true)
+      # Streaming may be requested either via `inputs[:stream]` (the
+       # newer Workers AI shape) or `options: { stream: true }` (the
+       # 3rd-arg "options" contract). Accept both so callers can use
+       # whichever idiom matches the model docs they're following.
+      streaming = (inputs.is_a?(Hash) && (inputs[:stream] == true || inputs['stream'] == true)) ||
+                  (options.is_a?(Hash) && (options[:stream] == true || options['stream'] == true))
       cf = Cloudflare
 
       js_promise = `

--- a/lib/cloudflare_workers/ai.rb
+++ b/lib/cloudflare_workers/ai.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+# await: true
+#
+# Phase 10 — Workers AI binding wrapper.
+#
+# `Cloudflare::AI.run(model, inputs, binding: env['cloudflare.AI'])`
+# wraps `env.AI.run(model, inputs, options)` and returns a Ruby Hash so
+# Sinatra routes can call:
+#
+#     ai = env['cloudflare.AI']
+#     out = Cloudflare::AI.run(
+#             '@cf/google/gemma-4-26b-a4b-it',
+#             { messages: [
+#                 { role: 'system', content: 'You are a helpful assistant.' },
+#                 { role: 'user',   content: 'こんにちは' }
+#             ] },
+#             binding: ai
+#           ).__await__
+#     out['response']  # => "..."
+#
+# Streaming (`stream: true`) returns the raw JS ReadableStream wrapped
+# in `Cloudflare::AI::Stream` so a route can hand it to a Server-Sent
+# Events response. See `lib/cloudflare_workers.rb#build_js_response`
+# for the SSE / ReadableStream pass-through.
+
+require 'json'
+
+module Cloudflare
+  class AIError < StandardError
+    attr_reader :model, :operation
+    def initialize(message, model: nil, operation: nil)
+      @model = model
+      @operation = operation
+      super("[Cloudflare::AI] model=#{model || '?'} op=#{operation || 'run'}: #{message}")
+    end
+  end
+
+  module AI
+    # Default REST options forwarded to env.AI.run as the third argument.
+    DEFAULT_OPTIONS = {}.freeze
+
+    # Run a Workers AI model. Returns a JS Promise that resolves to a
+    # Ruby Hash for non-streaming calls, or to a Cloudflare::AI::Stream
+    # wrapping the JS ReadableStream for streaming calls.
+    #
+    # @param model [String] catalog model id, e.g. '@cf/google/gemma-4-26b-a4b-it'
+    # @param inputs [Hash] model inputs (messages / prompt / max_tokens / etc.)
+    # @param binding [JS object] env.AI binding (required)
+    # @param options [Hash] gateway / extra options forwarded as the 3rd arg
+    def self.run(model, inputs, binding: nil, options: nil)
+      # Use a JS-side null check because `binding` may be a raw JS object
+      # (env.AI), which has no Ruby `#nil?` method on the prototype.
+      bound = !`(#{binding} == null)`
+      raise AIError.new('AI binding not bound (env.AI is null)', model: model) unless bound
+      js_inputs = ruby_to_js(inputs)
+      js_options = options ? ruby_to_js(options) : `({})`
+      ai_binding = binding
+      err_klass = Cloudflare::AIError
+      stream_klass = Cloudflare::AI::Stream
+      streaming = inputs.is_a?(Hash) && (inputs[:stream] == true || inputs['stream'] == true)
+      cf = Cloudflare
+
+      js_promise = `
+        (async function() {
+          var out;
+          try {
+            out = await #{ai_binding}.run(#{model}, #{js_inputs}, #{js_options});
+          } catch (e) {
+            #{Kernel}.$raise(#{err_klass}.$new(e && e.message ? e.message : String(e), Opal.hash({ model: #{model}, operation: 'run' })));
+          }
+          return out;
+        })()
+      `
+
+      js_result = js_promise.__await__
+
+      if streaming
+        # Workers AI returns a ReadableStream<Uint8Array> when stream:true.
+        # Wrap it so the Sinatra route can return it as an SSE body.
+        stream_klass.new(js_result)
+      else
+        cf.js_to_ruby(js_result)
+      end
+    end
+
+    # Convert a Ruby value (Hash / Array / String / Numeric / true / false / nil)
+    # into a plain JS object suitable for env.AI.run inputs.
+    def self.ruby_to_js(val)
+      if val.is_a?(Hash)
+        obj = `({})`
+        val.each do |k, v|
+          ks = k.to_s
+          jv = ruby_to_js(v)
+          `#{obj}[#{ks}] = #{jv}`
+        end
+        obj
+      elsif val.is_a?(Array)
+        arr = `([])`
+        val.each do |v|
+          jv = ruby_to_js(v)
+          `#{arr}.push(#{jv})`
+        end
+        arr
+      elsif val.is_a?(Symbol)
+        val.to_s
+      else
+        val
+      end
+    end
+
+    # Streaming wrapper. Holds the raw JS ReadableStream<Uint8Array>
+    # returned by env.AI.run when `stream: true` is set. Sinatra routes
+    # return this from a route body and `build_js_response` recognises
+    # it via duck-typing (`#sse_stream?`) to pass the stream straight
+    # into `new Response(stream, …)`.
+    class Stream
+      attr_reader :js_stream
+
+      def initialize(js_stream)
+        @js_stream = js_stream
+      end
+
+      def sse_stream?
+        true
+      end
+
+      def each; end
+      def close; end
+    end
+  end
+
+  # Generic JS->Ruby for the common Workers AI response shape:
+  #   { response: "...", usage: { prompt_tokens: ... } }
+  # Recursively converts nested objects + arrays.
+  def self.js_to_ruby(js_val)
+    return nil if `#{js_val} == null`
+    return js_val if `typeof #{js_val} === 'string' || typeof #{js_val} === 'number' || typeof #{js_val} === 'boolean'`
+    if `Array.isArray(#{js_val})`
+      out = []
+      len = `#{js_val}.length`
+      i = 0
+      while i < len
+        out << js_to_ruby(`#{js_val}[#{i}]`)
+        i += 1
+      end
+      return out
+    end
+    if `typeof #{js_val} === 'object'`
+      h = {}
+      keys = `Object.keys(#{js_val})`
+      len = `#{keys}.length`
+      i = 0
+      while i < len
+        k = `#{keys}[#{i}]`
+        h[k] = js_to_ruby(`#{js_val}[#{k}]`)
+        i += 1
+      end
+      return h
+    end
+    js_val
+  end
+end

--- a/package.json
+++ b/package.json
@@ -14,14 +14,16 @@
     "test:workers": "bin/test-on-workers",
     "deploy": "npm run build && wrangler deploy",
     "build:test": "ruby bin/compile-erb && OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -r cloudflare_workers -r homurabi_templates -o build/smoke-test.mjs test/smoke.rb 2>build/opal.stderr.log",
-    "test": "npm run build:test && node --import ./src/setup-node-crypto.mjs build/smoke-test.mjs && npm run test:http && npm run test:crypto && npm run test:jwt",
+    "test": "npm run build:test && node --import ./src/setup-node-crypto.mjs build/smoke-test.mjs && npm run test:http && npm run test:crypto && npm run test:jwt && npm run test:ai",
     "build:http-test": "OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -o build/http-smoke.mjs test/http_smoke.rb 2>build/opal.stderr.log",
     "test:http": "npm run build:http-test && node --import ./src/setup-node-crypto.mjs build/http-smoke.mjs",
     "build:crypto-test": "OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -o build/crypto-smoke.mjs test/crypto_smoke.rb 2>build/opal.stderr.log",
     "test:crypto": "npm run build:crypto-test && node --import ./src/setup-node-crypto.mjs build/crypto-smoke.mjs",
     "build:jwt-test": "OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -o build/jwt-smoke.mjs test/jwt_smoke.rb 2>build/opal.stderr.log",
     "test:jwt": "npm run build:jwt-test && node --import ./src/setup-node-crypto.mjs build/jwt-smoke.mjs",
-    "clean": "rm -f build/hello.no-exit.mjs build/smoke-test.mjs build/http-smoke.mjs build/crypto-smoke.mjs build/jwt-smoke.mjs build/homurabi_templates.rb build/homurabi_assets.rb build/opal.stderr.log"
+    "build:ai-test": "OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -o build/ai-smoke.mjs test/ai_smoke.rb 2>build/opal.stderr.log",
+    "test:ai": "npm run build:ai-test && node --import ./src/setup-node-crypto.mjs build/ai-smoke.mjs",
+    "clean": "rm -f build/hello.no-exit.mjs build/smoke-test.mjs build/http-smoke.mjs build/crypto-smoke.mjs build/jwt-smoke.mjs build/ai-smoke.mjs build/homurabi_templates.rb build/homurabi_assets.rb build/opal.stderr.log"
   },
   "devDependencies": {
     "wrangler": "^3.99.0"

--- a/public/style.css
+++ b/public/style.css
@@ -37,6 +37,7 @@ body:has(.chat-shell) { max-width: 56em; }
 .chat-msg-error     { background: #ffe5e5; border-color: #f7a3a3; }
 .chat-empty { color: var(--muted); text-align: center; padding: 2em; }
 .chat-suggest { background: #f4f4f4; border: 1px dashed #ccc; padding: .3em .8em; border-radius: 4px; cursor: pointer; }
+.chat-visually-hidden { position: absolute; left: -10000px; top: auto; width: 1px; height: 1px; overflow: hidden; }
 .chat-composer { display: flex; flex-direction: column; gap: .5em; }
 .chat-composer textarea { width: 100%; padding: .8em; border: 1px solid #ccc; border-radius: 6px; font: inherit; resize: vertical; }
 .chat-composer-actions { display: flex; gap: .8em; align-items: center; flex-wrap: wrap; }

--- a/public/style.css
+++ b/public/style.css
@@ -13,3 +13,36 @@ footer { margin-top: 3em; color: var(--muted); font-size: .9em; border-top: 1px 
 table { border-collapse: collapse; width: 100%; margin: 1em 0; }
 th, td { border: 1px solid #ddd; padding: .4em .6em; text-align: left; }
 th { background: #fafafa; }
+
+/* ----- Phase 10 — /chat UI ------------------------------------------ */
+body:has(.chat-shell) { max-width: 56em; }
+.nav-chat { color: var(--brand); font-weight: 700; }
+.chat-shell { display: flex; flex-direction: column; gap: 1em; }
+.chat-hero { background: linear-gradient(135deg, #0073bb 0%, #5a31b5 100%); color: #fff; padding: 1.5em; border-radius: 10px; }
+.chat-hero h1 { color: #fff; margin: 0 0 .2em 0; font-size: 1.6em; }
+.chat-hero-accent { color: #ffd166; font-family: 'JetBrains Mono', Menlo, monospace; font-size: .8em; }
+.chat-hero-sub { margin: 0 0 .6em 0; }
+.chat-hero-meta { margin: 0; font-size: .85em; opacity: .9; }
+.chat-tag { display: inline-block; padding: .05em .5em; margin-right: .3em; border-radius: 12px; background: rgba(255,255,255,.15); font-size: .8em; text-transform: uppercase; letter-spacing: .5px; }
+.chat-hero-meta code { background: rgba(255,255,255,.18); color: #fff; }
+.chat-banner { padding: .6em 1em; border-radius: 6px; display: flex; align-items: center; gap: .6em; flex-wrap: wrap; font-size: .9em; }
+.chat-banner-info { background: #fff8e1; border: 1px solid #f6c344; }
+.chat-banner-ok   { background: #e6f7ec; border: 1px solid #4caf7e; }
+.chat-thread { display: flex; flex-direction: column; gap: .8em; min-height: 16em; max-height: 28em; overflow: auto; padding: 1em; border: 1px solid #ddd; border-radius: 8px; background: #fafbfc; }
+.chat-msg { padding: .6em .9em; border-radius: 8px; max-width: 90%; white-space: pre-wrap; word-break: break-word; }
+.chat-msg-role { font-size: .7em; text-transform: uppercase; letter-spacing: .5px; color: var(--muted); margin-bottom: .25em; }
+.chat-msg-user      { align-self: flex-end; background: #d8ecff; border: 1px solid #a4ccef; }
+.chat-msg-assistant { align-self: flex-start; background: #fff; border: 1px solid #ddd; }
+.chat-msg-system    { align-self: stretch; background: #f4f4f4; border: 1px dashed #ccc; font-style: italic; }
+.chat-msg-error     { background: #ffe5e5; border-color: #f7a3a3; }
+.chat-empty { color: var(--muted); text-align: center; padding: 2em; }
+.chat-suggest { background: #f4f4f4; border: 1px dashed #ccc; padding: .3em .8em; border-radius: 4px; cursor: pointer; }
+.chat-composer { display: flex; flex-direction: column; gap: .5em; }
+.chat-composer textarea { width: 100%; padding: .8em; border: 1px solid #ccc; border-radius: 6px; font: inherit; resize: vertical; }
+.chat-composer-actions { display: flex; gap: .8em; align-items: center; flex-wrap: wrap; }
+.chat-composer-actions button { padding: .55em 1.2em; border: 0; border-radius: 6px; cursor: pointer; font-weight: 600; }
+#chat-send  { background: var(--brand); color: #fff; }
+#chat-clear { background: #eee; color: #444; }
+#chat-login-btn { background: var(--accent); color: #fff; border: 0; padding: .35em 1em; border-radius: 4px; cursor: pointer; }
+.chat-model-pick { font-size: .85em; color: var(--muted); margin-right: auto; }
+.chat-foot { color: var(--muted); font-size: .8em; }

--- a/test/ai_smoke.rb
+++ b/test/ai_smoke.rb
@@ -1,0 +1,286 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+# await: true
+#
+# Phase 10 — Workers AI binding smoke tests.
+#
+# Verifies:
+#   - Cloudflare::AI.run forwards to env.AI.run with correct model + inputs.
+#   - Empty / missing responses raise Cloudflare::AIError.
+#   - Hash inputs (messages array) are converted to plain JS objects.
+#   - The fallback model is invoked when the primary returns empty
+#     (mocked at the binding level — primary returns "" once, fallback
+#     returns a real string).
+#   - Streaming wrapper (sse_stream?) is returned when stream:true.
+#
+# Usage:
+#   npm run test:ai
+#   npm test            # full suite
+
+require 'json'
+require 'cloudflare_workers/ai'
+
+# ---------------------------------------------------------------------
+# Stub a fake env.AI binding. `__test_ai_response__` controls the next
+# response; `__test_ai_calls__` records every invocation so assertions
+# can verify the binding received the right model + inputs.
+# ---------------------------------------------------------------------
+`
+globalThis.__test_ai_calls__ = [];
+globalThis.__test_ai_response_queue__ = [];
+globalThis.__test_ai_make_binding__ = function() {
+  return {
+    run: async function(model, inputs, options) {
+      globalThis.__test_ai_calls__.push({ model: model, inputs: inputs, options: options });
+      var queue = globalThis.__test_ai_response_queue__;
+      if (queue.length === 0) {
+        return { response: 'default-mock', usage: { prompt_tokens: 1, completion_tokens: 1 } };
+      }
+      var next = queue.shift();
+      if (next && next.__throw__) {
+        throw new Error(next.message || 'mock failure');
+      }
+      return next;
+    }
+  };
+};
+globalThis.__test_ai_reset__ = function() {
+  globalThis.__test_ai_calls__ = [];
+  globalThis.__test_ai_response_queue__ = [];
+};
+`
+
+module SmokeTest
+  @passed = 0
+  @failed = 0
+  @errors = []
+
+  # Each test block awaits internal Promises with `.__await__` and
+  # returns a plain boolean. Because this file is `# await: true`, the
+  # block's compiled JS function is `async`, so `block.call` returns a
+  # JS Promise that we must explicitly await before reading its value.
+  # Without the explicit await, the assertion would PASS on the truthy
+  # Promise object and the actual rejection would only surface as an
+  # unhandled rejection long after report() printed totals.
+  #
+  # `assert` itself is also async (it lives in a `# await: true` file),
+  # so callers must `__await__` each assert to enforce sequential
+  # execution — otherwise asserts race against each other through the
+  # shared globalThis.__test_ai_response_queue__.
+  def self.assert(label, &block)
+    raw = block.call
+    result = if `(#{raw} != null && typeof #{raw} === 'object' && typeof #{raw}.then === 'function')`
+               raw.__await__
+             else
+               raw
+             end
+    if result
+      @passed += 1
+      $stdout.puts "  PASS  #{label}"
+    else
+      @failed += 1
+      @errors << label
+      $stdout.puts "  FAIL  #{label}"
+    end
+    nil
+  rescue Exception => e
+    @failed += 1
+    @errors << "#{label} (#{e.class}: #{e.message})"
+    $stdout.puts "  CRASH #{label} — #{e.class}: #{e.message}"
+    nil
+  end
+
+  # Sequential wrapper around assert: returns a plain Promise that the
+  # top-level code awaits with `.__await__`, which serialises async
+  # tests so they don't race over the shared mock binding queue.
+  def self.assert!(label, &block)
+    p = assert(label, &block)
+    # Ensure we hand back a thenable so the top-level call can `__await__`
+    # it. If `assert` returned a non-Promise (synchronous path), wrap it.
+    if `(#{p} != null && typeof #{p} === 'object' && typeof #{p}.then === 'function')`
+      p
+    else
+      `Promise.resolve(#{p})`
+    end
+  end
+
+  def self.report
+    total = @passed + @failed
+    $stdout.puts ''
+    $stdout.puts "#{total} tests, #{@passed} passed, #{@failed} failed"
+    if @errors.any?
+      $stdout.puts 'Failures:'
+      @errors.each { |e| $stdout.puts "  - #{e}" }
+    end
+    @failed == 0
+  end
+end
+
+def fresh_binding
+  `globalThis.__test_ai_reset__()`
+  `globalThis.__test_ai_make_binding__()`
+end
+
+def push_response(hash)
+  js_obj = `({})`
+  hash.each { |k, v| ks = k.to_s; `#{js_obj}[#{ks}] = #{v}` }
+  `globalThis.__test_ai_response_queue__.push(#{js_obj})`
+end
+
+def push_throw(message)
+  obj = `({ __throw__: true, message: #{message} })`
+  `globalThis.__test_ai_response_queue__.push(#{obj})`
+end
+
+def call_count
+  `globalThis.__test_ai_calls__.length`
+end
+
+def last_call
+  idx = call_count - 1
+  return nil if idx < 0
+  raw = `globalThis.__test_ai_calls__[#{idx}]`
+  Cloudflare.js_to_ruby(raw)
+end
+
+$stdout.puts '=== homurabi Phase 10 — Workers AI smoke ==='
+$stdout.puts ''
+
+# ---------------------------------------------------------------------
+# 1. Cloudflare::AI.run basic
+# ---------------------------------------------------------------------
+$stdout.puts '--- Cloudflare::AI.run ---'
+
+SmokeTest.assert!('returns Hash with response/usage keys') {
+  binding = fresh_binding
+  push_response('response' => 'hello from mock', 'usage' => `({ prompt_tokens: 3 })`)
+  out = Cloudflare::AI.run('@cf/google/gemma-4-26b-a4b-it',
+                           { messages: [{ role: 'user', content: 'hi' }] },
+                           binding: binding).__await__
+  out.is_a?(Hash) && out['response'] == 'hello from mock'
+}.__await__
+
+SmokeTest.assert!('forwards model id and Hash inputs to env.AI.run') {
+  binding = fresh_binding
+  push_response('response' => 'ok')
+  Cloudflare::AI.run('@cf/google/gemma-4-26b-a4b-it',
+                     { messages: [{ role: 'user', content: 'こんにちは' }], max_tokens: 64 },
+                     binding: binding).__await__
+  c = last_call
+  c && c['model'] == '@cf/google/gemma-4-26b-a4b-it' &&
+    c['inputs'].is_a?(Hash) &&
+    c['inputs']['max_tokens'] == 64 &&
+    c['inputs']['messages'].is_a?(Array) &&
+    c['inputs']['messages'][0]['content'] == 'こんにちは'
+}.__await__
+
+SmokeTest.assert!('symbol keys in inputs become string keys in JS') {
+  binding = fresh_binding
+  push_response('response' => 'ok')
+  Cloudflare::AI.run('@cf/openai/gpt-oss-120b',
+                     { messages: [{ role: :user, content: 'sym' }], stream: false },
+                     binding: binding).__await__
+  c = last_call
+  c['inputs']['messages'][0]['role'] == 'user' && c['inputs'].key?('stream')
+}.__await__
+
+SmokeTest.assert!('AIError raised when binding is nil') {
+  raised = false
+  begin
+    Cloudflare::AI.run('@cf/google/gemma-4-26b-a4b-it', { messages: [] }, binding: nil).__await__
+  rescue Cloudflare::AIError
+    raised = true
+  end
+  raised
+}.__await__
+
+SmokeTest.assert!('AIError raised when binding throws') {
+  binding = fresh_binding
+  push_throw('quota exceeded')
+  raised = false
+  begin
+    Cloudflare::AI.run('@cf/google/gemma-4-26b-a4b-it',
+                       { messages: [{ role: 'user', content: 'x' }] },
+                       binding: binding).__await__
+  rescue Cloudflare::AIError => e
+    raised = e.message.include?('quota exceeded')
+  end
+  raised
+}.__await__
+
+# ---------------------------------------------------------------------
+# 2. Streaming wrapper
+# ---------------------------------------------------------------------
+$stdout.puts ''
+$stdout.puts '--- Cloudflare::AI::Stream (stream: true) ---'
+
+SmokeTest.assert!('stream:true returns Cloudflare::AI::Stream wrapper') {
+  binding = `({
+    run: async function(model, inputs) {
+      // Real Workers AI returns a ReadableStream<Uint8Array>; we mock
+      // with a stream that emits one chunk and closes.
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("data: {\\\"response\\\":\\\"chunk1\\\"}\\n\\n"));
+          controller.close();
+        }
+      });
+    }
+  })`
+  out = Cloudflare::AI.run('@cf/google/gemma-4-26b-a4b-it',
+                           { messages: [{ role: 'user', content: 'hi' }], stream: true },
+                           binding: binding).__await__
+  out.is_a?(Cloudflare::AI::Stream) && out.sse_stream? == true
+}.__await__
+
+# ---------------------------------------------------------------------
+# 3. Fallback flow (simulated at the route layer would do this; this
+#    asserts the building block behaves predictably under failure +
+#    immediately-empty conditions).
+# ---------------------------------------------------------------------
+$stdout.puts ''
+$stdout.puts '--- Fallback / empty-response handling ---'
+
+SmokeTest.assert!('first call returns empty string -> caller can detect') {
+  binding = fresh_binding
+  push_response('response' => '')
+  out = Cloudflare::AI.run('@cf/google/gemma-4-26b-a4b-it',
+                           { messages: [] }, binding: binding).__await__
+  out['response'] == ''
+}.__await__
+
+SmokeTest.assert!('two sequential calls hit binding twice (fallback retry pattern)') {
+  binding = fresh_binding
+  push_response('response' => '')
+  push_response('response' => 'fallback won')
+  Cloudflare::AI.run('@cf/google/gemma-4-26b-a4b-it', { messages: [] }, binding: binding).__await__
+  out2 = Cloudflare::AI.run('@cf/openai/gpt-oss-120b',  { messages: [] }, binding: binding).__await__
+  call_count == 2 && out2['response'] == 'fallback won'
+}.__await__
+
+# ---------------------------------------------------------------------
+# 4. KV-style history persistence (smoke verifying the JSON round trip
+#    that the chat route relies on; this is "what would KV store?").
+# ---------------------------------------------------------------------
+$stdout.puts ''
+$stdout.puts '--- chat history JSON round-trip ---'
+
+SmokeTest.assert!('history Array<Hash> JSON encode/decode preserves roles+content') {
+  history = [
+    { 'role' => 'user',      'content' => 'ping' },
+    { 'role' => 'assistant', 'content' => 'pong from mock' },
+    { 'role' => 'user',      'content' => '日本語テスト' }
+  ]
+  raw = history.to_json
+  back = JSON.parse(raw)
+  back == history
+}.__await__
+
+SmokeTest.assert!('history truncation keeps only last N entries') {
+  history = (1..50).map { |i| { 'role' => i.even? ? 'assistant' : 'user', 'content' => "msg #{i}" } }
+  trimmed = history.last(32)
+  trimmed.size == 32 && trimmed.first['content'] == 'msg 19' && trimmed.last['content'] == 'msg 50'
+}.__await__
+
+ok = SmokeTest.report
+exit(ok ? 0 : 1)

--- a/views/_message.erb
+++ b/views/_message.erb
@@ -1,0 +1,5 @@
+<%# Single message partial. Rendered server-side on /chat reload. %>
+<article class="chat-msg chat-msg-<%= @msg && @msg['role'] %>">
+  <header class="chat-msg-role"><%= @msg && @msg['role'] %></header>
+  <div class="chat-msg-body"><%= @msg && @msg['content'] %></div>
+</article>

--- a/views/_message.erb
+++ b/views/_message.erb
@@ -1,5 +1,13 @@
-<%# Single message partial. Rendered server-side on /chat reload. %>
-<article class="chat-msg chat-msg-<%= @msg && @msg['role'] %>">
-  <header class="chat-msg-role"><%= @msg && @msg['role'] %></header>
-  <div class="chat-msg-body"><%= @msg && @msg['content'] %></div>
+<%# Single message partial. Reserved for future use by route handlers
+    that want to render a single chat message out-of-band of the main
+    /chat ERB (e.g. an HTMX-style "append one message" endpoint). The
+    main /chat view inlines the loop for performance.
+
+    The values are HTML-escaped because they originate in user input
+    persisted in KV and can therefore carry arbitrary characters. %>
+<% role    = (@msg && @msg['role'])    ? Rack::Utils.escape_html(@msg['role'].to_s)    : '' %>
+<% content = (@msg && @msg['content']) ? Rack::Utils.escape_html(@msg['content'].to_s) : '' %>
+<article class="chat-msg chat-msg-<%= role %>">
+  <header class="chat-msg-role"><%= role %></header>
+  <div class="chat-msg-body"><%= content %></div>
 </article>

--- a/views/chat.erb
+++ b/views/chat.erb
@@ -26,14 +26,15 @@
   </div>
 
   <main class="chat-thread" id="chat-thread"
-        data-session-id="<%= @session_id %>"
-        data-primary-model="<%= @primary_model %>"
-        data-fallback-model="<%= @fallback_model %>">
+        data-session-id="<%= Rack::Utils.escape_html(@session_id) %>"
+        data-primary-model="<%= Rack::Utils.escape_html(@primary_model) %>"
+        data-fallback-model="<%= Rack::Utils.escape_html(@fallback_model) %>">
     <% if @history && @history.any? %>
       <% @history.each do |msg| %>
-        <article class="chat-msg chat-msg-<%= msg['role'] %>">
-          <header class="chat-msg-role"><%= msg['role'] %></header>
-          <div class="chat-msg-body"><%= msg['content'] %></div>
+        <% role = Rack::Utils.escape_html(msg['role'].to_s) %>
+        <article class="chat-msg chat-msg-<%= role %>">
+          <header class="chat-msg-role"><%= role %></header>
+          <div class="chat-msg-body"><%= Rack::Utils.escape_html(msg['content'].to_s) %></div>
         </article>
       <% end %>
     <% else %>
@@ -46,7 +47,9 @@
   </main>
 
   <form id="chat-form" class="chat-composer" autocomplete="off">
+    <label for="chat-input" class="chat-visually-hidden">Chat message</label>
     <textarea id="chat-input" name="content" rows="2"
+              aria-label="Chat message"
               placeholder="日本語でも英語でも。Enterで送信、Shift+Enterで改行。"></textarea>
     <div class="chat-composer-actions">
       <label class="chat-model-pick">
@@ -62,7 +65,7 @@
   </form>
 
   <p class="chat-foot">
-    Session id <code id="chat-session-id"><%= @session_id %></code>
+    Session id <code id="chat-session-id"><%= Rack::Utils.escape_html(@session_id) %></code>
     &middot; persisted to KV under <code>chat:&lt;session&gt;</code>
     &middot; <a href="/api/chat/health">health</a>
   </p>

--- a/views/chat.erb
+++ b/views/chat.erb
@@ -1,0 +1,209 @@
+<div class="chat-shell">
+  <header class="chat-hero">
+    <div class="chat-hero-text">
+      <h1>homurabi <span class="chat-hero-accent">/chat</span></h1>
+      <p class="chat-hero-sub">
+        Real Sinatra route, hosted on Cloudflare Workers, talking to
+        <strong>Workers AI</strong> via the <code>env.AI</code> binding.
+      </p>
+      <p class="chat-hero-meta">
+        <span class="chat-tag">model</span>
+        <code id="chat-current-model"><%= @primary_model %></code>
+        <span class="chat-tag">fallback</span>
+        <code><%= @fallback_model %></code>
+        <span class="chat-tag">history</span>
+        <code>Workers KV</code>
+        <span class="chat-tag">auth</span>
+        <code>JWT (HS256)</code>
+      </p>
+    </div>
+  </header>
+
+  <div id="chat-auth-banner" class="chat-banner chat-banner-info">
+    Mint a demo token to start chatting:
+    <button id="chat-login-btn" type="button">Issue HS256 token (demo)</button>
+    <span id="chat-auth-status">no token</span>
+  </div>
+
+  <main class="chat-thread" id="chat-thread"
+        data-session-id="<%= @session_id %>"
+        data-primary-model="<%= @primary_model %>"
+        data-fallback-model="<%= @fallback_model %>">
+    <% if @history && @history.any? %>
+      <% @history.each do |msg| %>
+        <article class="chat-msg chat-msg-<%= msg['role'] %>">
+          <header class="chat-msg-role"><%= msg['role'] %></header>
+          <div class="chat-msg-body"><%= msg['content'] %></div>
+        </article>
+      <% end %>
+    <% else %>
+      <div class="chat-empty">
+        No messages yet. Say
+        <button class="chat-suggest" type="button" data-text="こんにちは！自己紹介してください">こんにちは！自己紹介してください</button>
+        to get started.
+      </div>
+    <% end %>
+  </main>
+
+  <form id="chat-form" class="chat-composer" autocomplete="off">
+    <textarea id="chat-input" name="content" rows="2"
+              placeholder="日本語でも英語でも。Enterで送信、Shift+Enterで改行。"></textarea>
+    <div class="chat-composer-actions">
+      <label class="chat-model-pick">
+        model
+        <select id="chat-model">
+          <option value="<%= @primary_model %>"><%= @primary_model %> (Gemma 4)</option>
+          <option value="<%= @fallback_model %>"><%= @fallback_model %> (gpt-oss-120b)</option>
+        </select>
+      </label>
+      <button id="chat-send" type="submit">Send</button>
+      <button id="chat-clear" type="button">Clear history</button>
+    </div>
+  </form>
+
+  <p class="chat-foot">
+    Session id <code id="chat-session-id"><%= @session_id %></code>
+    &middot; persisted to KV under <code>chat:&lt;session&gt;</code>
+    &middot; <a href="/api/chat/health">health</a>
+  </p>
+</div>
+
+<script>
+  (function () {
+    var threadEl = document.getElementById('chat-thread');
+    var formEl   = document.getElementById('chat-form');
+    var inputEl  = document.getElementById('chat-input');
+    var modelEl  = document.getElementById('chat-model');
+    var clearEl  = document.getElementById('chat-clear');
+    var loginEl  = document.getElementById('chat-login-btn');
+    var statusEl = document.getElementById('chat-auth-status');
+    var bannerEl = document.getElementById('chat-auth-banner');
+    var sendBtn  = document.getElementById('chat-send');
+    var sessionId = threadEl.getAttribute('data-session-id');
+
+    function tokenKey() { return 'homurabi.chat.jwt'; }
+    function getToken() { return window.localStorage.getItem(tokenKey()); }
+    function setToken(t) {
+      if (t) window.localStorage.setItem(tokenKey(), t);
+      else   window.localStorage.removeItem(tokenKey());
+      reflectAuth();
+    }
+    function reflectAuth() {
+      var t = getToken();
+      if (t) {
+        statusEl.textContent = 'token: ' + t.slice(0, 14) + '…';
+        bannerEl.classList.remove('chat-banner-info');
+        bannerEl.classList.add('chat-banner-ok');
+      } else {
+        statusEl.textContent = 'no token';
+        bannerEl.classList.add('chat-banner-info');
+        bannerEl.classList.remove('chat-banner-ok');
+      }
+    }
+    reflectAuth();
+
+    function authHeaders() {
+      var h = { 'content-type': 'application/json' };
+      var t = getToken();
+      if (t) h['authorization'] = 'Bearer ' + t;
+      return h;
+    }
+
+    function appendMessage(role, content) {
+      var wrap = document.createElement('article');
+      wrap.className = 'chat-msg chat-msg-' + role;
+      var head = document.createElement('header');
+      head.className = 'chat-msg-role';
+      head.textContent = role;
+      var body = document.createElement('div');
+      body.className = 'chat-msg-body';
+      body.textContent = content;
+      wrap.appendChild(head);
+      wrap.appendChild(body);
+      // Drop the empty-state placeholder once a real message arrives.
+      var empty = threadEl.querySelector('.chat-empty');
+      if (empty) empty.remove();
+      threadEl.appendChild(wrap);
+      threadEl.scrollTop = threadEl.scrollHeight;
+      return wrap;
+    }
+
+    document.querySelectorAll('.chat-suggest').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        inputEl.value = btn.getAttribute('data-text') || btn.textContent;
+        inputEl.focus();
+      });
+    });
+
+    loginEl.addEventListener('click', async function () {
+      try {
+        var resp = await fetch('/api/login?alg=HS256', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ username: 'chat-demo', role: 'user' })
+        });
+        if (!resp.ok) throw new Error('login http ' + resp.status);
+        var json = await resp.json();
+        setToken(json.access_token);
+      } catch (err) {
+        alert('login failed: ' + err.message);
+      }
+    });
+
+    clearEl.addEventListener('click', async function () {
+      if (!confirm('Delete this session\'s history?')) return;
+      try {
+        var resp = await fetch('/api/chat/messages?session=' + encodeURIComponent(sessionId), {
+          method: 'DELETE',
+          headers: authHeaders()
+        });
+        if (!resp.ok) throw new Error('clear http ' + resp.status);
+        threadEl.innerHTML = '<div class="chat-empty">History cleared.</div>';
+      } catch (err) {
+        alert('clear failed: ' + err.message);
+      }
+    });
+
+    inputEl.addEventListener('keydown', function (ev) {
+      if (ev.key === 'Enter' && !ev.shiftKey) {
+        ev.preventDefault();
+        formEl.requestSubmit();
+      }
+    });
+
+    formEl.addEventListener('submit', async function (ev) {
+      ev.preventDefault();
+      var text = inputEl.value.trim();
+      if (text === '') return;
+      if (!getToken()) {
+        alert('Please mint a JWT first (the button above).');
+        return;
+      }
+      appendMessage('user', text);
+      inputEl.value = '';
+      sendBtn.disabled = true;
+      var pending = appendMessage('assistant', '…');
+      try {
+        var resp = await fetch('/api/chat/messages', {
+          method: 'POST',
+          headers: authHeaders(),
+          body: JSON.stringify({
+            session: sessionId,
+            content: text,
+            model: modelEl.value
+          })
+        });
+        var json = await resp.json();
+        if (!resp.ok) throw new Error(json.error || ('http ' + resp.status));
+        pending.querySelector('.chat-msg-body').textContent = json.reply || '(no reply)';
+        document.getElementById('chat-current-model').textContent = json.model;
+      } catch (err) {
+        pending.querySelector('.chat-msg-body').textContent = 'error: ' + err.message;
+        pending.classList.add('chat-msg-error');
+      } finally {
+        sendBtn.disabled = false;
+        inputEl.focus();
+      }
+    });
+  })();
+</script>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -13,6 +13,7 @@
       <a href="/hello/world">/hello/world</a>
       <a href="/about">About</a>
       <a href="/d1/users">D1 users</a>
+      <a href="/chat" class="nav-chat">Chat ⚡</a>
     </nav>
     <hr>
     <%= @content %>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -40,8 +40,11 @@ binding = "AI"
 # Phase 10: same default-deny pattern for the AI demo (`/chat`,
 # `/api/chat/*`, `/test/ai`). Workers AI is metered; leaving the chat
 # endpoints publicly reachable in production lets anyone burn the
-# account's neuron quota. Default ON in dev (this file ships with "1")
-# but flip to "0" before deploying anywhere with real users.
+# account's neuron quota. Default OFF in the committed config so a
+# casual `wrangler deploy` cannot accidentally expose the metered
+# routes — flip to "1" only in a private dev environment (e.g.
+# `wrangler dev --var HOMURABI_ENABLE_AI_DEMOS:1`) or with a per-env
+# section.
 [vars]
 HOMURABI_ENABLE_CRYPTO_DEMOS = "0"
-HOMURABI_ENABLE_AI_DEMOS = "1"
+HOMURABI_ENABLE_AI_DEMOS = "0"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -22,9 +22,26 @@ id = "64ee32f1c6c64f85af9591e827da7462"
 binding = "BUCKET"
 bucket_name = "homurabi-bucket"
 
+# Phase 10: Workers AI binding. Routes reach this from Ruby as
+# `env['cloudflare.AI']` and pass it to `Cloudflare::AI.run(model, …)`.
+# The binding name "AI" matches the Cloudflare convention; the runtime
+# implements env.AI.run(model, inputs, options) automatically once
+# wrangler dev / deploy attaches the AI gateway. No account-side
+# configuration is required for `wrangler dev` (it proxies to the live
+# Workers AI catalog) once `wrangler login` has run.
+[ai]
+binding = "AI"
+
 # Phase 7: gating for the educational crypto routes (`/test/crypto`,
 # `/demo/crypto`). Default OFF — those routes generate fresh RSA keys
 # and run PBKDF2 per request, so leaving them open in production is a
 # CPU-DoS vector. Set to "1" only in dev or behind a private route.
+#
+# Phase 10: same default-deny pattern for the AI demo (`/chat`,
+# `/api/chat/*`, `/test/ai`). Workers AI is metered; leaving the chat
+# endpoints publicly reachable in production lets anyone burn the
+# account's neuron quota. Default ON in dev (this file ships with "1")
+# but flip to "0" before deploying anywhere with real users.
 [vars]
 HOMURABI_ENABLE_CRYPTO_DEMOS = "0"
+HOMURABI_ENABLE_AI_DEMOS = "1"


### PR DESCRIPTION
## Summary

Phase 10 of the homurabi roadmap: a real Sinatra `/chat` route hosted on
Cloudflare Workers that talks to **Cloudflare Workers AI** through the
`env.AI` binding. JWT-protected (Phase 8), KV-persisted history (Phase 5),
two models pinned (no Llama):

- **primary**: `@cf/google/gemma-4-26b-a4b-it` — Google Gemma 4, 256K ctx, $0.10/$0.30 per Mtok, Japanese-friendly
- **fallback**: `@cf/openai/gpt-oss-120b` — OpenAI gpt-oss-120b, 128K ctx, $0.35/$0.75 per Mtok

This PR adds the `Cloudflare::AI.run` wrapper, the chat UI + API, the
`[ai] binding = "AI"` wiring, the SSE pass-through plumbing for the
forthcoming streaming endpoint, and 10 mock-binding smoke tests.

## What changes

- `lib/cloudflare_workers/ai.rb` (new) — `Cloudflare::AI.run(model, inputs, binding:)` wraps `env.AI.run` as an awaitable Ruby call. Returns Hash for non-streaming, `Cloudflare::AI::Stream` (wrapping the JS `ReadableStream`) when `stream: true`. `Cloudflare::AIError` for any binding throw.
- `lib/cloudflare_workers.rb` — `env.AI` surfaced as `env['cloudflare.AI']`. `build_js_response` gains an SSE pass-through (`#sse_stream?` duck-typing) and a single-chunk `[status, body]` post-await override (Sinatra's `invoke` snapshots `response.status` synchronously when it sees a Promise body, so this is the only path that lets a route express a non-200 status from an `await`-bound branch).
- `wrangler.toml` — `[ai] binding = "AI"` and `HOMURABI_ENABLE_AI_DEMOS = "1"` default-on-in-dev gate (mirrors Phase 7's `HOMURABI_ENABLE_CRYPTO_DEMOS`).
- `app/hello.rb` — `GET /chat` (ERB UI), `POST/GET/DELETE /api/chat/messages` (JWT-gated, KV-persisted), `GET /api/chat/health`, `GET /test/ai` (live AI smoke), `GET /test/ai/debug` (raw response shape inspector). `CHAT_MODELS` constant pins primary + fallback. `App.extract_ai_text` handles both legacy `{response: "..."}` and OpenAI-style `{choices: [{message: {content/reasoning: "..."}}]}` shapes.
- `views/chat.erb` + `views/_message.erb` (new) — vanilla-JS UI, Enter-to-send, KV history pre-rendered server-side. `public/style.css` gains the chat styles. `views/layout.erb` gets a "Chat ⚡" nav link.
- `test/ai_smoke.rb` (+10 tests) — mock AI binding, asserts model id forwarding, symbol→string key conversion, `AIError` on null/throwing binding, Stream wrapper for `stream:true`, fallback retry semantics, KV history JSON round-trip + truncation. `package.json` wires `npm run test:ai` into the default suite.
- `README.md` — Phase 10 hero section at the top of the file (live capture + table + model rationale).

## Live verification

`wrangler ai models --json` confirms both models in the catalog:

```
@cf/google/gemma-4-26b-a4b-it  task=Text Generation
@cf/openai/gpt-oss-120b        task=Text Generation
```

End-to-end against `wrangler dev`:

```
POST /api/login?alg=HS256 → JWT issued
POST /api/chat/messages   → Gemma 4 returns Japanese in 2.2-3.5 s
POST /api/chat/messages   → gpt-oss-120b returns English in 1.4-2.6 s
GET  /api/chat/messages   → KV-persisted history returned
DELETE /api/chat/messages → cleared

JWT enforcement matrix:
  no Authorization header → 401 "missing bearer token"
  bad token "Bearer x"    → 401 "invalid token: Invalid segment encoding"
  valid HS256 token       → 200 + Gemma 4 reply
```

Multi-turn KV memory verified: Gemma 4 remembered persona ("homurabiです。")
across two turns of the same session.

Full curl/jq capture lives in `.artifacts/phase10-ai/api-evidence.txt`.

## Test plan

- [x] `wrangler ai models --json` confirms `@cf/google/gemma-4-26b-a4b-it` + `@cf/openai/gpt-oss-120b` are in the live catalog
- [x] `npm test` — 179 tests pass (was 169, +10 from `test/ai_smoke.rb`)
- [x] `npm run dev` then `curl http://127.0.0.1:8788/test/ai` exercises both models against live Workers AI (real responses, ~1-3 s wall time per model)
- [x] `POST /api/chat/messages` with valid HS256 token returns 200 + Gemma 4 Japanese reply
- [x] `POST /api/chat/messages` with no/bad token returns 401 with the right reason string
- [x] `GET /api/chat/messages?session=...` returns KV-persisted history
- [x] `DELETE /api/chat/messages?session=...` clears KV
- [x] `/chat` HTML loads with the hero block, model dropdown, login button, and JWT-flow hookup
- [x] Llama-family models intentionally excluded per Phase 10 master directive

## Notes for review

A few sharp edges discovered + fixed during the build (see `.artifacts/phase10-ai/REPORT.md` for the full table):

- `binding.nil?` blew up because `env.AI` is a raw JS object — replaced with a JS-level `(v != null)` check via `ai_binding?`.
- `Sinatra::JwtAuth#authenticate!` uses `halt` (= `throw :halt`); the throw escapes Opal's async/await boundary before Sinatra's `catch :halt` wrapper sees it, so the chat routes do JWT verify inline and return `[401, body]` instead.
- `status N; next body` after an `await` does not stick on Opal-Workers because `Sinatra::Base#invoke` snapshots `response.status` synchronously when it sees a Promise body. Routes that need a post-await non-200 status return `[status, body]`; the new `build_js_response` branch picks that up.
- Workers AI returns `{response: null}` for OpenAI-compatible models (Gemma 4, gpt-oss-*); the visible answer lives in `choices[0].message.content` (or `.reasoning` when truncated). `App.extract_ai_text` covers both shapes.

Streaming (Phase 10.3) infrastructure is in place (`Cloudflare::AI::Stream`, `#sse_stream?` duck-typing) but the streaming chat route is deferred to a follow-up worktree — the synchronous round-trip is well under Workers' 30 s wall budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)