### PR TITLE
feat(phase9): Scheduled Workers — Cron Triggers via Sinatra DSL

### DIFF
--- a/.artifacts/phase9-cron/REPORT.md
+++ b/.artifacts/phase9-cron/REPORT.md
@@ -1,0 +1,273 @@
+# Phase 9 — Scheduled Workers (Cron Triggers) — REPORT
+
+> **Status: shipped (worktree feature/phase9-cron, ready for PR to main)**
+> Branch: `feature/phase9-cron`
+> Tests: 27 (smoke) + 14 (http) + 85 (crypto) + 43 (jwt) + **29 (scheduled, NEW)** = **198 total, all green**
+> Build: `5.6 MB` `build/hello.no-exit.mjs` (essentially flat vs Phase 8)
+
+## What ships
+
+A Sinatra-style `schedule '*/5 * * * *' do |event| ... end` DSL that wires
+straight into the Cloudflare Workers `scheduled(event, env, ctx)` lifecycle.
+The block runs in a fresh `Sinatra::Scheduled::ScheduledContext` instance
+that exposes the same `db` / `kv` / `bucket` helpers as HTTP routes plus a
+`wait_until(promise)` wrapper around `ctx.waitUntil`.
+
+```ruby
+class App < Sinatra::Base
+  register Sinatra::Scheduled
+
+  schedule '*/5 * * * *', name: 'heartbeat' do |event|
+    db.execute_insert(
+      'INSERT INTO heartbeats (cron, scheduled_at, fired_at, note) VALUES (?, ?, ?, ?)',
+      [event.cron, event.scheduled_time.to_i, Time.now.to_i, 'phase9-heartbeat']
+    ).__await__
+  end
+
+  schedule '0 */1 * * *', name: 'hourly-housekeeping' do |event|
+    raw  = kv.get('cron:hourly-counter').__await__
+    prev = raw ? JSON.parse(raw)['count'].to_i : 0
+    kv.put('cron:hourly-counter', { 'count' => prev + 1, 'last_cron' => event.cron, ... }.to_json).__await__
+  end
+end
+```
+
+`wrangler.toml`:
+```toml
+[triggers]
+crons = [
+  "*/5 * * * *",   # heartbeat — writes a row to D1 every 5 minutes
+  "0 */1 * * *",   # hourly housekeeping — KV cleanup demo
+]
+```
+
+## Files added / changed
+
+| Path | Status | Purpose |
+|---|---|---|
+| `lib/sinatra/scheduled.rb` | **new** | Sinatra extension — `schedule` DSL, `Job` registry, `dispatch_scheduled` class method, `ScheduledContext` runtime (`db`/`kv`/`bucket`/`wait_until`) |
+| `lib/cloudflare_workers/scheduled.rb` | **new** | `Cloudflare::ScheduledEvent`, JS hook installer (`globalThis.__HOMURABI_SCHEDULED_DISPATCH__`), `dispatch_js` / `dispatch` / `await_promise` helpers |
+| `lib/cloudflare_workers.rb` | edit | `require 'cloudflare_workers/scheduled'` |
+| `src/worker.mjs` | edit | adds `scheduled(event, env, ctx)` export — forwards to `__HOMURABI_SCHEDULED_DISPATCH__`, wraps in `ctx.waitUntil(work)` |
+| `app/hello.rb` | edit | registers `Sinatra::Scheduled`, demo `schedule` blocks (heartbeat → D1, hourly → KV), `/test/scheduled` & `/test/scheduled/run` introspection routes (gated by `HOMURABI_ENABLE_SCHEDULED_DEMOS`) |
+| `wrangler.toml` | edit | `[triggers] crons = […]` example, `HOMURABI_ENABLE_SCHEDULED_DEMOS = "0"` default-deny gate |
+| `bin/schema.sql` | edit | adds `heartbeats` table for the heartbeat cron demo |
+| `test/scheduled_smoke.rb` | **new** | 29 tests — DSL, validation, dispatch, ScheduledContext, JS hook |
+| `package.json` | edit | `build:scheduled-test` + `test:scheduled` scripts; `clean` updated; full `test` chain extended |
+| `README.md` | edit | Phase 9 section under "Scheduled Workers" |
+
+## Test coverage breakdown
+
+`test/scheduled_smoke.rb` — **29 cases, 9 groups**:
+
+1. **DSL registration (5)** — exact registration, cron capture, `:name` option,
+   default name, multi-`schedule` accumulation
+2. **Cron expression validation (5)** — empty string rejection, 4-field /
+   7-field rejection, no-block rejection, 6-field acceptance
+3. **Dispatch: exact-string match (4)** — only matching job fires,
+   ScheduledEvent flows through, no-match returns `fired=0`, results record
+   `name`/`cron`/`ok`
+4. **ScheduledContext helpers (5)** — `#db` / `#kv` / `#bucket` / `#env`
+   are defined; `env['cloudflare.cron']` and `env['cloudflare.scheduled']`
+   are present; D1 / KV wrappers are constructed when bindings are set
+5. **`Cloudflare::ScheduledEvent.from_js` (2)** — JS event → Ruby Time
+   conversion, missing `scheduledTime` defaults to `Time.now`
+6. **`Cloudflare::Scheduled.dispatch` (2)** — explicit `app=` route and
+   no-app raise
+7. **Custom `:match` proc (2)** — `match: ->(c) { true }` catches arbitrary
+   crons; `match: ->(c) { false }` skips
+8. **Per-job error isolation (2)** — sibling job survives an exception;
+   error class + message captured in `results` array
+9. **JS dispatcher hook (2)** — `globalThis.__HOMURABI_SCHEDULED_DISPATCH__`
+   is installed; full round-trip from JS hook → Sinatra dispatcher → block
+   side effect
+
+```text
+$ npm test
+27 tests, 27 passed, 0 failed   (smoke)
+14 tests, 14 passed, 0 failed   (http)
+85 tests, 85 passed, 0 failed   (crypto)
+43 tests, 43 passed, 0 failed   (jwt)
+29 tests, 29 passed, 0 failed   (scheduled — NEW)
+```
+
+## In-Worker (live `wrangler dev`) verification
+
+Brought up `npx wrangler dev --test-scheduled --local` against a fresh
+local D1 + KV. Both demo schedules fire end-to-end through
+`worker.mjs#scheduled` → `globalThis.__HOMURABI_SCHEDULED_DISPATCH__`
+→ `Cloudflare::Scheduled.dispatch_js` → `Sinatra::Scheduled` → user block
+→ live D1 / KV write.
+
+### Workers runtime path (`/__scheduled?cron=…`)
+
+```
+$ curl 'http://127.0.0.1:8787/__scheduled?cron=*/5+*+*+*+*'
+Ran scheduled event
+
+$ wrangler d1 execute homurabi-db --local --command "SELECT COUNT(*) FROM heartbeats WHERE note='phase9-heartbeat';"
+6  →  7   (incremented by 1 per firing)
+
+$ curl 'http://127.0.0.1:8787/__scheduled?cron=0+*/1+*+*+*'
+Ran scheduled event
+
+$ curl http://127.0.0.1:8787/kv/cron:hourly-counter
+{"key":"cron:hourly-counter","value":"{\"count\":7,\"last_cron\":\"0 */1 * * *\",\"last_run_at\":1776429651,\"last_sched_t\":1776429651}"}
+```
+
+### Self-test introspection (`/test/scheduled` + `/test/scheduled/run`)
+
+`HOMURABI_ENABLE_SCHEDULED_DEMOS=1` (default-deny gate) flipped via
+`.dev.vars`:
+
+```json
+$ curl http://127.0.0.1:8787/test/scheduled
+{"jobs":[
+  {"name":"heartbeat","cron":"*/5 * * * *","file":null,"line":null},
+  {"name":"hourly-housekeeping","cron":"0 */1 * * *","file":null,"line":null}
+]}
+
+$ curl -X POST 'http://127.0.0.1:8787/test/scheduled/run?cron=*/5%20*%20*%20*%20*'
+{"fired":1,"total":2,"results":[{"name":"heartbeat","cron":"*/5 * * * *","ok":true,"duration":0.003}],"cron":"*/5 * * * *","registered_crons":["*/5 * * * *","0 */1 * * *"]}
+
+$ curl -X POST 'http://127.0.0.1:8787/test/scheduled/run?cron=99%20*%20*%20*%20*'
+{"fired":0,"total":2,"results":[],"cron":"99 * * * *","registered_crons":["*/5 * * * *","0 */1 * * *"]}
+
+$ # 4 manual hourly fires from a fresh KV → counter increments correctly
+$ curl http://127.0.0.1:8787/kv/cron:hourly-counter
+{"key":"cron:hourly-counter","value":"{\"count\":4,\"last_cron\":\"0 */1 * * *\", ...}"}
+```
+
+The non-zero `duration` (1–3 ms) and the actual D1 / KV state changes
+prove the dispatcher truly waits for the inner `__await__` chain — i.e.
+side effects complete before the dispatcher records `ok: true`.
+
+## Production safety
+
+`/test/scheduled` and `/test/scheduled/run` are gated by
+`HOMURABI_ENABLE_SCHEDULED_DEMOS` (defaults to `"0"` in `wrangler.toml`),
+so they 404 in production. The reasoning is identical to Phase 7's
+`HOMURABI_ENABLE_CRYPTO_DEMOS`: `/test/scheduled/run` lets any
+unauthenticated caller burn binding quota by manually firing every
+registered cron. Flip to `"1"` only in dev or behind a private route.
+
+The `scheduled(event, env, ctx)` runtime entry point is _not_ gated — it
+is the legitimate Cloudflare runtime hook for declared cron triggers.
+
+## Design decisions
+
+### `define_method` instead of `instance_exec`
+
+The first cut used `ctx.instance_exec(event, &job.block)` to run the
+user block. That hit two showstoppers under Opal:
+
+1. `instance_exec` is sync, so the block's `__await__` calls did not
+   actually wait — KV / D1 writes silently fire-and-forget.
+2. Exceptions raised inside the block became rejected Promises that
+   our outer rescue could not catch — every job reported `ok: true`
+   even when it threw.
+
+Fix: convert the block to a method via `define_method` on
+`ScheduledContext`, then call it via `unbound_method.bind(ctx).call`.
+Opal's `# await: true` mode promotes `define_method`'d methods to async
+functions, so `__await__` works inside the body and exceptions
+propagate as rejected Promises that the literal `.__await__` keyword
+re-throws as Ruby exceptions.
+
+This is the same trick `Sinatra::Base.generate_method` uses for HTTP
+route blocks — see `vendor/sinatra/base.rb:1813`.
+
+### Explicit `.__await__` at every async boundary
+
+Opal's `# await: true` is **token-driven**: only the literal
+`.__await__` token is rewritten to JS `await`. Calling a helper that
+does `__await__` internally returns a Promise that the caller still has
+to await again. So:
+
+- `dispatch_scheduled` ends each job with `invoke_scheduled_job(...).__await__`
+- `invoke_scheduled_job` ends the bound-method call with `.__await__`
+- `Cloudflare::Scheduled.dispatch_js` ends with `.dispatch_scheduled(...).__await__`
+- `/test/scheduled/run` ends with `.dispatch_scheduled(...).__await__`
+- Tests use `app.dispatch_scheduled(...).__await__`
+
+The thenable JS check (`typeof p.then === 'function'`) is kept around the
+`.__await__` so non-Promise returns (sync blocks in tests) are not
+needlessly awaited.
+
+### `await_promise` helper
+
+`Cloudflare::Scheduled.await_promise(p) = p.__await__` exists as a
+single-spot indirection that future code paths (e.g. the AI streaming
+demo in Phase 10) can call without scattering `__await__` markers
+through their own files. It is async itself, so its own callers still
+have to `__await__` the helper's return — there is no escape from the
+"every async boundary needs a literal `__await__`" rule. The docstring
+calls this out so future maintainers don't fall back into the trap.
+
+### Cron expression validation
+
+We enforce 5- or 6-field whitespace structure at `schedule` time so a
+typo throws `ArgumentError` at boot, not silently never-fires at
+runtime. We don't attempt to parse the cron expression itself —
+Cloudflare always passes back the literal string from `wrangler.toml`,
+so exact-string match is the right policy and a parser would just be
+dead weight.
+
+A `match:` keyword lets test code override the matcher with
+`match: ->(_c) { true }` for "always run" jobs without touching
+wrangler.toml.
+
+### Per-job error isolation
+
+`dispatch_scheduled` wraps each job in its own `begin / rescue ::Exception`
+so one bad job never kills its siblings. Each result Hash carries
+`name`, `cron`, `ok`, `duration`, and (on failure) `error: "Class: msg"`.
+
+### Local stdout invisibility (NOT a bug)
+
+`puts` from inside a `scheduled`-context block doesn't reach
+`wrangler dev` stdout the way it does from HTTP routes. We confirmed
+this is purely a console.log capture quirk — D1 and KV writes from the
+same block DO land. Diagnostics during development used HTTP route
+inspection of the persisted state instead of `puts`.
+
+## Out of scope (deferred)
+
+- **Dynamic cron registration** — Workers requires static
+  `wrangler.toml` declaration. Sinatra DSL therefore has no
+  `unschedule` / `reschedule`.
+- **Cron expression parsing** — exact-string match is what the
+  runtime guarantees; no need.
+- **Cross-job sequencing** — each job runs independently; no
+  declarative "run B after A" yet. Use `wait_until` to keep work
+  alive past the dispatcher's return when needed.
+
+## Bench
+
+| Phase | bundle (uncompressed) |
+|---|---|
+| Phase 8 (a5b1b20) | 5.6 MB |
+| **Phase 9 (this branch)** | 5.6 MB (+ ~6 KB for scheduled dispatcher + Sinatra extension) |
+
+Negligible bundle delta — Cron Triggers add Ruby code only, no new
+vendored gems.
+
+## Phase 8 → Phase 9 carryover
+
+- Re-uses Phase 7 `# await: true` + `__await__` async pattern verbatim
+  for D1 / KV bindings.
+- Re-uses Phase 8's "register helper, gate by env var" production
+  safety pattern (`HOMURABI_ENABLE_SCHEDULED_DEMOS`).
+- Re-uses Phase 7's `bin/init-local-d1` SQLite bootstrap pattern;
+  schema simply adds a `heartbeats` table.
+
+## Next-phase enablers
+
+Phase 11 candidates that this work unlocks:
+- **Queues binding** — `schedule`-style DSL would mirror `consume` for
+  Queue triggers; ScheduledContext is already the right shape for that.
+- **Durable Objects** — `wait_until` / `ctx` plumbing carries straight
+  through.
+- **Workers AI streaming (Phase 10.3)** — `Cloudflare::Scheduled.await_promise`
+  + the worker.mjs `ctx.waitUntil` pattern is the exact bridge needed
+  for SSE streams.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ opposite bet: no DSL, real Sinatra, real Rack, real middleware chain.
 - [Net::HTTP works (Phase 6)](#nethttp-works-phase-6)
 - [Crypto works (Phase 7)](#crypto-works-phase-7)
 - [JWT 認証 (Phase 8)](#jwt-認証-phase-8)
+- [Scheduled Workers — Cron Triggers (Phase 9)](#scheduled-workers--cron-triggers-phase-9)
 - [Project status & phases](#project-status--phases)
 - [Strict no-fallback policy](#strict-no-fallback-policy)
 - [License](#license)
@@ -764,6 +765,136 @@ $ curl -X POST http://127.0.0.1:8787/api/login/refresh \
 - **カスタム署名アルゴリズム** — SigningAlgorithm module は有効だが、
   Opal async 対応の完了はユーザー側の責務。
 
+## Scheduled Workers — Cron Triggers (Phase 9)
+
+Cloudflare Workers が `[triggers] crons` の時刻に発火する `scheduled(event,
+env, ctx)` ハンドラを Sinatra DSL で書けるようにする。**Sidekiq-Cron や
+whenever のようにアプリと同じファイルに `schedule` ブロックを並べる**だけで、
+Workers ランタイムからのクロン発火が D1 / KV / R2 に届く。
+
+```ruby
+class App < Sinatra::Base
+  register Sinatra::Scheduled
+
+  # 5分ごとに D1 に行を入れる
+  schedule '*/5 * * * *', name: 'heartbeat' do |event|
+    db.execute_insert(
+      'INSERT INTO heartbeats (cron, scheduled_at, fired_at, note) VALUES (?, ?, ?, ?)',
+      [event.cron, event.scheduled_time.to_i, Time.now.to_i, 'phase9-heartbeat']
+    ).__await__
+  end
+
+  # 1時間ごとに KV カウンタを更新（read-modify-write）
+  schedule '0 */1 * * *', name: 'hourly-housekeeping' do |event|
+    raw  = kv.get('cron:hourly-counter').__await__
+    prev = raw ? JSON.parse(raw)['count'].to_i : 0
+    kv.put('cron:hourly-counter', { 'count' => prev + 1, 'last_run_at' => Time.now.to_i }.to_json).__await__
+  end
+end
+```
+
+`wrangler.toml`:
+
+```toml
+[triggers]
+crons = [
+  "*/5 * * * *",   # heartbeat — 5分ごと D1 書き込み
+  "0 */1 * * *",   # hourly housekeeping — 1時間ごと KV カウンタ
+]
+```
+
+### ローカルでクロンを手動発火
+
+Cloudflare Workers の標準的な方法と全く同じ。`wrangler dev --test-scheduled`
+を立てて、`/__scheduled` エンドポイントに `cron` をクエリパラメータで投げる。
+
+```bash
+$ npm run dev   # 内部で wrangler dev を起動
+
+# 別ターミナルから — 5分ごとのクロンを今すぐ発火
+$ curl 'http://127.0.0.1:8787/__scheduled?cron=*/5+*+*+*+*'
+Ran scheduled event
+
+# D1 に行が入った
+$ wrangler d1 execute homurabi-db --local \
+    --command "SELECT * FROM heartbeats ORDER BY id DESC LIMIT 1;"
+{"cron":"*/5 * * * *","note":"phase9-heartbeat", ...}
+```
+
+### イントロスペクション (`/test/scheduled`)
+
+Phase 7 / 8 の `/test/crypto` と同じノリで、開発時に登録済みクロンの一覧と
+任意発火を curl で確認できる。**default deny** — `wrangler.toml [vars]
+HOMURABI_ENABLE_SCHEDULED_DEMOS = "1"`（あるいは `.dev.vars` で上書き）
+にしないと 404 を返す。
+
+```bash
+$ curl http://127.0.0.1:8787/test/scheduled
+{"jobs":[
+  {"name":"heartbeat","cron":"*/5 * * * *", ...},
+  {"name":"hourly-housekeeping","cron":"0 */1 * * *", ...}
+]}
+
+# 手動で hourly cron だけ発火
+$ curl -X POST 'http://127.0.0.1:8787/test/scheduled/run?cron=0%20*/1%20*%20*%20*'
+{"fired":1,"total":2,
+ "results":[{"name":"hourly-housekeeping","cron":"0 */1 * * *","ok":true,"duration":0.003}],
+ "cron":"0 */1 * * *","registered_crons":["*/5 * * * *","0 */1 * * *"]}
+```
+
+### `schedule` API
+
+| 引数 | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `cron` | String | ✓ | 5- または 6-フィールドのクロン式。`wrangler.toml` の `[triggers] crons` の文字列と完全一致しないとマッチしない |
+| `name:` | String | — | ログ用ラベル（既定: クロン式そのもの） |
+| `match:` | Proc | — | 完全一致以外のマッチング（テスト用、`->(c) { true }` で常時発火） |
+| ブロック | `\|event\|` | ✓ | `Cloudflare::ScheduledEvent` (`#cron` / `#scheduled_time` / `#type`) を受け取る |
+
+`schedule` ブロックの中では HTTP ルートと同じヘルパが使える:
+
+| ヘルパ | 値 |
+|---|---|
+| `db` | `Cloudflare::D1Database` ラッパ（D1 バインディング設定時のみ） |
+| `kv` | `Cloudflare::KVNamespace` ラッパ |
+| `bucket` | `Cloudflare::R2Bucket` ラッパ |
+| `env` | `'cloudflare.cron'` / `'cloudflare.scheduled_time'` / `'cloudflare.env'` / `'cloudflare.ctx'` を含む Hash |
+| `wait_until(promise)` | `ctx.waitUntil(promise)` 相当。長時間 Promise をハンドラ完了後も走らせる |
+| `logger` | `info` / `warn` / `error` / `debug` を持つ簡易ロガー |
+
+### `# await: true` ルール
+
+D1 / KV / R2 / fetch / 暗号系と同じく、内部で `__await__` を呼ぶブロックは
+**Opal `# await: true` モード**で動く。`app/hello.rb` の先頭にこのマジックコメントが
+ある限り、`schedule do ... end` の中で `kv.get(key).__await__` のような同期風
+構文が使える（ES8 `await` に変換される）。
+
+ブロックが投げた例外は **per-job rescue** に捕まり、結果の `results` 配列に
+`ok: false, error: "Class: msg"` として記録される。一つのクロンが落ちても兄弟ジョブは
+止まらない。
+
+### 制約 (Cloudflare Workers の物理制約により未対応)
+
+- **動的クロン登録** — `wrangler.toml` の静的宣言のみ。実行時に
+  `unschedule` / `reschedule` する API は提供しない（プラットフォーム制約）。
+- **長時間ジョブ** — Workers の CPU 時間制限あり（30s wall、〜30s CPU）。
+  外部 fetch を伴う重い処理は `wait_until` で続行させる。
+- **クロス-job sequencing** — 各ジョブは並列・独立。`A の完了を待って B`
+  のような宣言的シーケンスはなし（必要なら呼び出し順を `schedule` 宣言で
+  制御）。
+
+### テスト
+
+29 ケースの回帰スイート (`test/scheduled_smoke.rb`) — DSL 登録、クロン式
+バリデーション、ディスパッチ、`ScheduledContext` ヘルパ、`ScheduledEvent.from_js`、
+カスタム match proc、per-job エラー隔離、`globalThis.__HOMURABI_SCHEDULED_DISPATCH__`
+JS フック経由の round-trip。
+
+```bash
+$ npm run test:scheduled
+29 tests, 29 passed, 0 failed
+```
+
 ## Project status & phases
 
 The project follows a strict four-phase plan (see
@@ -780,6 +911,7 @@ of each phase:
 | **Phase 6** | HTTP client foundation — `Cloudflare::HTTP.fetch` wrapping `globalThis.fetch`, plus a `Net::HTTP` shim (`get` / `get_response` / `post_form`) and `Kernel#URI` so unmodified Ruby HTTP code can reach the network through the Workers `fetch` API. | ✅ shipped on `feature/phase6-fetch`. 14 new smoke tests pass; demos at `/demo/http` and `/demo/http/raw` hit the public ipify API. |
 | **Phase 7** | Crypto primitives — full RS/PS/ES JWT alg coverage, RSA-OAEP, AES-GCM/CBC/CTR, ECDH (P-256/384/521 + X25519), Ed25519/EdDSA, OpenSSL::BN, KDF (PBKDF2 + HKDF), SecureRandom, PEM I/O. node:crypto sync + Web Crypto subtle async hybrid; CTR streaming via per-block subtle calls; binary plaintext byte-transparent; verify raises on key/algo errors and only returns false on signature mismatch. | ✅ shipped on `feature/phase7-crypto`. 85 crypto smoke + Workers self-test endpoint `/test/crypto` (17 cases) + bin/test-on-workers shell script for in-Worker regression. |
 | **Phase 8** | JWT 認証フレームワーク — vendored ruby-jwt v2.9.3 に Opal/async パッチを適用。HS/RS/PS/ES/EdDSA 全アルゴリズム対応、`Sinatra::JwtAuth` ヘルパで `authenticate!` / `current_user` / `issue_token`、KV-backed refresh token、`/api/login?alg=<name>` で全アルゴリズムが実働 Workers 上で発行・検証できる。`JWT.encode` / `JWT.decode` は subtle バックエンドのため async（caller が `.__await__`）、HS256 系は sync。 | ✅ shipped on `feature/phase8-jwt`. 43 jwt smoke + Workers self-test `/test/crypto` が 26 ケース（JWT 9 追加）+ dogfooding で全 7 alg のログイン→/api/me→refresh を実測。 |
+| **Phase 9** | Scheduled Workers (Cron Triggers) — `src/worker.mjs#scheduled` を経由して `globalThis.__HOMURABI_SCHEDULED_DISPATCH__` から Sinatra ディスパッチャに委譲。**`Sinatra::Scheduled` 拡張**で `schedule '*/5 * * * *' do \|event\| ... end` DSL（`db` / `kv` / `bucket` / `wait_until` ヘルパ込み）。ブロックは `define_method` 経由でコンパイルされるため `# await: true` の `__await__` がそのまま使え、D1 / KV へのリード・モディファイ・ライトが Workers ランタイムから正しく到達する。per-job 例外隔離 + `/test/scheduled` `/test/scheduled/run` 内省 API（`HOMURABI_ENABLE_SCHEDULED_DEMOS` で default deny）。 | ✅ shipped on `feature/phase9-cron`. 29 scheduled smoke + 実機 `wrangler dev --test-scheduled` で `/__scheduled?cron=...` 経由の D1 行追加と KV カウンタ increment を実測（4 連発で `count: 1→4`）。 |
 
 ### Definition of Done (from PLAN.md §1.1)
 

--- a/app/hello.rb
+++ b/app/hello.rb
@@ -20,6 +20,7 @@ require 'securerandom'
 require 'base64'
 require 'jwt'
 require 'sinatra/jwt_auth'
+require 'sinatra/scheduled'
 
 class App < Sinatra::Base
   # Phase 8 — JWT auth. The secret is the default HS256 path; asymmetric
@@ -32,6 +33,10 @@ class App < Sinatra::Base
   register Sinatra::JwtAuth
   set :jwt_secret, 'homurabi-phase8-demo-secret-change-me-in-prod'
   set :jwt_algorithm, 'HS256'
+  # Phase 9 — Cron Trigger DSL. Use `schedule '*/5 * * * *' do ... end`
+  # below; matching jobs are dispatched from `src/worker.mjs#scheduled`
+  # via `globalThis.__HOMURABI_SCHEDULED_DISPATCH__`.
+  register Sinatra::Scheduled
   # --- Cloudflare binding helpers ------------------------------------
   # These let routes access D1/KV/R2 with the same brevity as
   # ActiveRecord's `User.find(id)` pattern, without introducing an ORM.
@@ -48,6 +53,17 @@ class App < Sinatra::Base
       cf_env = env['cloudflare.env']
       return false unless cf_env
       val = `(#{cf_env} && #{cf_env}.HOMURABI_ENABLE_CRYPTO_DEMOS) || ''`
+      val.to_s == '1'
+    end
+
+    # Phase 9 — gate for the scheduled introspection / manual-fire
+    # routes. `/test/scheduled/run` writes to D1 + KV without auth, so
+    # leaving it open in production lets any caller burn binding quota.
+    # Default OFF; flip via wrangler [vars] HOMURABI_ENABLE_SCHEDULED_DEMOS=1.
+    def scheduled_demos_enabled?
+      cf_env = env['cloudflare.env']
+      return false unless cf_env
+      val = `(#{cf_env} && #{cf_env}.HOMURABI_ENABLE_SCHEDULED_DEMOS) || ''`
       val.to_s == '1'
     end
   end
@@ -752,6 +768,113 @@ class App < Sinatra::Base
         'uuid'            => SecureRandom.uuid
       }
     }.to_json
+  end
+  # ------------------------------------------------------------------
+  # Phase 9 — Cloudflare Workers Cron Triggers.
+  #
+  # Each `schedule` block is invoked from `src/worker.mjs#scheduled`
+  # via `globalThis.__HOMURABI_SCHEDULED_DISPATCH__` whenever the
+  # Workers runtime fires the matching cron (declared in
+  # `wrangler.toml [triggers] crons`). The block runs in a
+  # `Sinatra::Scheduled::ScheduledContext` instance, which exposes
+  # the same `db` / `kv` / `bucket` helpers as HTTP routes plus a
+  # `wait_until(promise)` wrapper around `ctx.waitUntil`.
+  #
+  # The block argument is a `Cloudflare::ScheduledEvent` with `.cron`
+  # (the literal cron string from wrangler.toml) and `.scheduled_time`
+  # (a Ruby Time at the epoch the event was scheduled for).
+  #
+  # Local manual trigger:
+  #   npx wrangler dev --test-scheduled
+  #   curl 'http://127.0.0.1:8787/__scheduled?cron=*/5+*+*+*+*'
+  # ------------------------------------------------------------------
+  schedule '*/5 * * * *', name: 'heartbeat' do |event|
+    # Insert one row into D1's heartbeats table per cron firing.
+    # Falls back to a no-op when DB is not bound (test envs).
+    if db
+      db.execute_insert(
+        'INSERT INTO heartbeats (cron, scheduled_at, fired_at, note) VALUES (?, ?, ?, ?)',
+        [event.cron, event.scheduled_time.to_i, Time.now.to_i, 'phase9-heartbeat']
+      ).__await__
+    end
+  end
+
+  schedule '0 */1 * * *', name: 'hourly-housekeeping' do |event|
+    # Demo: bump a KV counter so we can prove hourly cron runs from
+    # outside a test by inspecting `/kv/cron:hourly-counter` over HTTP.
+    # Falls back to a no-op when KV is not bound (test envs).
+    if kv
+      raw  = kv.get('cron:hourly-counter').__await__
+      prev = 0
+      if raw
+        begin
+          prev = JSON.parse(raw)['count'].to_i
+        rescue StandardError
+          prev = 0
+        end
+      end
+      payload = {
+        'count'        => prev + 1,
+        'last_cron'    => event.cron,
+        'last_run_at'  => Time.now.to_i,
+        'last_sched_t' => event.scheduled_time.to_i
+      }.to_json
+      kv.put('cron:hourly-counter', payload).__await__
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Phase 9 self-test endpoints — gated on HOMURABI_ENABLE_SCHEDULED_DEMOS.
+  #
+  # GET  /test/scheduled            → list every registered job (cron,
+  #                                    name, source location)
+  # POST /test/scheduled/run?cron=… → manually fire every job whose
+  #                                    cron expression equals the
+  #                                    query param. Same code path the
+  #                                    Workers runtime takes; lets us
+  #                                    smoke-test cron handlers from
+  #                                    a curl in `wrangler dev`
+  #                                    without waiting 5 minutes.
+  # ------------------------------------------------------------------
+  get '/test/scheduled' do
+    content_type 'application/json'
+    unless scheduled_demos_enabled?
+      status 404
+      next { 'error' => 'scheduled demos disabled (set HOMURABI_ENABLE_SCHEDULED_DEMOS=1 in wrangler vars)' }.to_json
+    end
+    {
+      'jobs' => App.scheduled_jobs.map do |job|
+        {
+          'name' => job.name,
+          'cron' => job.cron,
+          'file' => job.file,
+          'line' => job.line
+        }
+      end
+    }.to_json
+  end
+
+  post '/test/scheduled/run' do
+    content_type 'application/json'
+    unless scheduled_demos_enabled?
+      status 404
+      next({ 'error' => 'scheduled demos disabled (set HOMURABI_ENABLE_SCHEDULED_DEMOS=1 in wrangler vars)' }.to_json)
+    end
+    cron = params['cron'].to_s
+    if cron.empty?
+      status 400
+      next({ 'error' => 'missing cron query param (e.g. ?cron=*/5%20*%20*%20*%20*)' }.to_json)
+    end
+    # Use the same dispatcher the Workers runtime invokes. Pass the
+    # JS env / ctx so D1 / KV writes hit the live bindings. The
+    # dispatcher is async (it `__await__`s each job's body), so we
+    # MUST `__await__` its return Promise before serialising the
+    # result — otherwise the inner D1 / KV writes get torn down when
+    # the HTTP response is sent. The literal `__await__` token is
+    # what Opal scans for to emit a JS `await`.
+    event  = Cloudflare::ScheduledEvent.new(cron: cron, scheduled_time: Time.now)
+    result = App.dispatch_scheduled(event, env['cloudflare.env'], env['cloudflare.ctx']).__await__
+    result.merge('cron' => cron, 'registered_crons' => App.scheduled_jobs.map(&:cron)).to_json
   end
 end
 

--- a/app/hello.rb
+++ b/app/hello.rb
@@ -788,7 +788,17 @@ class App < Sinatra::Base
   #   npx wrangler dev --test-scheduled
   #   curl 'http://127.0.0.1:8787/__scheduled?cron=*/5+*+*+*+*'
   # ------------------------------------------------------------------
+  # Per-block guard: even though Phase 9 jobs are *registered*
+  # unconditionally (so `wrangler.toml`'s `[triggers] crons` declarations
+  # actually wire up to a Ruby handler), the *body* of these demo
+  # schedules is opt-in via the same `HOMURABI_ENABLE_SCHEDULED_DEMOS`
+  # var that gates `/test/scheduled*`. Without the flag, production
+  # cron firings short-circuit to a no-op so default deploys never
+  # accumulate heartbeat rows or burn KV write quota.
   schedule '*/5 * * * *', name: 'heartbeat' do |event|
+    cf_env = env['cloudflare.env']
+    enabled = cf_env && `(#{cf_env}.HOMURABI_ENABLE_SCHEDULED_DEMOS || '')`.to_s == '1'
+    next unless enabled
     # Insert one row into D1's heartbeats table per cron firing.
     # Falls back to a no-op when DB is not bound (test envs).
     if db
@@ -800,6 +810,9 @@ class App < Sinatra::Base
   end
 
   schedule '0 */1 * * *', name: 'hourly-housekeeping' do |event|
+    cf_env = env['cloudflare.env']
+    enabled = cf_env && `(#{cf_env}.HOMURABI_ENABLE_SCHEDULED_DEMOS || '')`.to_s == '1'
+    next unless enabled
     # Demo: bump a KV counter so we can prove hourly cron runs from
     # outside a test by inspecting `/kv/cron:hourly-counter` over HTTP.
     # Falls back to a no-op when KV is not bound (test envs).

--- a/bin/schema.sql
+++ b/bin/schema.sql
@@ -21,3 +21,18 @@ INSERT OR IGNORE INTO users (id, name) VALUES
   (2, 'Homurabi-chan'),
   (3, 'Sinatra'),
   (4, 'Opal');
+
+-- Phase 9 — Cron Trigger heartbeat demo. Each firing of the
+-- `*/5 * * * *` cron writes one row here. Verify the cron is
+-- actually wired by tailing this table in dev:
+--
+--   wrangler d1 execute homurabi-db --local \
+--     --command "SELECT * FROM heartbeats ORDER BY id DESC LIMIT 5;"
+--
+CREATE TABLE IF NOT EXISTS heartbeats (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  cron         TEXT    NOT NULL,
+  scheduled_at INTEGER NOT NULL,
+  fired_at     INTEGER NOT NULL,
+  note         TEXT
+);

--- a/lib/cloudflare_workers.rb
+++ b/lib/cloudflare_workers.rb
@@ -602,3 +602,11 @@ end
 # Workers adapter so user code can simply `require 'sinatra/base'`
 # and use Net::HTTP / Cloudflare::HTTP.fetch without an extra require.
 require 'cloudflare_workers/http'
+
+# Phase 9 — Scheduled (Cron Triggers) dispatcher. Installs the JS
+# `globalThis.__HOMURABI_SCHEDULED_DISPATCH__` hook that
+# `src/worker.mjs#scheduled` forwards every cron firing through.
+# Must be loaded after the Cloudflare::* binding wrappers above
+# because it constructs D1Database/KVNamespace/R2Bucket instances
+# inside the dispatcher's per-job env.
+require 'cloudflare_workers/scheduled'

--- a/lib/cloudflare_workers/scheduled.rb
+++ b/lib/cloudflare_workers/scheduled.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+# await: true
+#
+# Phase 9 — Cloudflare Workers Cron Trigger dispatcher.
+#
+# Cloudflare Workers fire `scheduled(event, env, ctx)` for each entry
+# in `wrangler.toml`'s `[triggers] crons = [...]` array. The runtime
+# guarantees `event.cron` is one of the cron expressions declared in
+# wrangler.toml; `event.scheduledTime` is the firing time as a JS
+# epoch-millis number.
+#
+# This file:
+#   1. Defines `Cloudflare::ScheduledEvent` — a Ruby wrapper around
+#      the JS ScheduledEvent so user blocks see plain Ruby values
+#      (`event.cron` -> String, `event.scheduled_time` -> Time).
+#
+#   2. Installs `globalThis.__HOMURABI_SCHEDULED_DISPATCH__` — the JS
+#      hook called from `src/worker.mjs#scheduled`. The hook receives
+#      the JS event/env/ctx, builds a Ruby ScheduledEvent, and calls
+#      `Sinatra::Scheduled::ClassMethods#dispatch_scheduled` on the
+#      Rack handler's app.
+#
+#   3. Exposes `Cloudflare::Scheduled.app=` so non-Sinatra Rack apps
+#      can hook the dispatcher too. By default, `Rack::Handler::
+#      CloudflareWorkers.app` (set by `run app` in user code) is used.
+#
+# Test entry point: `Cloudflare::Scheduled.dispatch(cron, scheduled_time, js_env, js_ctx)`
+# — used by `test/scheduled_smoke.rb` so the same code path that the
+# Workers runtime takes is exercised under Node, without needing the
+# JS dispatcher.
+
+require 'time'
+
+module Cloudflare
+  # Wrapper around the JS ScheduledEvent. The Workers runtime gives us:
+  #
+  #   event.cron          — String, e.g. '*/5 * * * *'
+  #   event.scheduledTime — Number (millis-since-epoch)
+  #   event.type          — String, always 'scheduled'
+  #   event.waitUntil(p)  — same shape as ctx.waitUntil(p)
+  #
+  # We surface these as Ruby idioms so user code never needs backticks.
+  class ScheduledEvent
+    attr_reader :cron, :scheduled_time, :type, :raw
+
+    def initialize(cron:, scheduled_time:, type: 'scheduled', raw: nil)
+      @cron = cron.to_s.freeze
+      @scheduled_time = scheduled_time
+      @type = type.to_s.freeze
+      @raw = raw
+    end
+
+    # Build a ScheduledEvent from the native JS event. `js_event` may
+    # be nil during smoke tests; in that case the caller passes the
+    # cron / scheduled_time via the keyword form above.
+    #
+    # JS undefined / null guards are written in JS land instead of
+    # delegating to `nil?` because Opal doesn't always coerce a bare
+    # JS undefined into Ruby's nil — calling `.nil?` on it raises
+    # TypeError.
+    def self.from_js(js_event)
+      return new(cron: '', scheduled_time: Time.now) if `#{js_event} == null`
+
+      cron      = `(#{js_event}.cron == null ? '' : String(#{js_event}.cron))`
+      type      = `(#{js_event}.type == null ? 'scheduled' : String(#{js_event}.type))`
+      has_sched = `(#{js_event}.scheduledTime != null)`
+      sched_t   = if has_sched
+                    sched_ms = `Number(#{js_event}.scheduledTime)`
+                    Time.at(sched_ms.to_f / 1000.0)
+                  else
+                    Time.now
+                  end
+
+      new(cron: cron, scheduled_time: sched_t, type: type, raw: js_event)
+    end
+
+    def to_h
+      {
+        'cron'           => cron,
+        'scheduled_time' => scheduled_time.to_i,
+        'type'           => type
+      }
+    end
+  end
+
+  # Dispatcher singleton. The Rack handler installs the JS hook on
+  # boot; user code never calls anything in this module directly.
+  module Scheduled
+    @app = nil
+
+    class << self
+      # Override the dispatch target. By default the dispatcher uses
+      # `Rack::Handler::CloudflareWorkers.app`, which is whatever the
+      # user passed to top-level `run app`. Tests use this to plug
+      # a fake Sinatra subclass without booting the full handler.
+      attr_accessor :app
+    end
+
+    # Install the JS-side dispatcher on globalThis. Idempotent — safe
+    # to call multiple times (last writer wins).
+    #
+    # NOTE: kept as a single-line backtick x-string. Opal's parser
+    # treats multi-line backtick strings as raw statements that don't
+    # return a value AND it tries to lex-as-Ruby everything inside,
+    # so JS comments containing the Ruby backtick delimiter (`...`)
+    # crash the build. Single-line form sidesteps both pitfalls.
+    def self.install_dispatcher
+      mod = self
+      `globalThis.__HOMURABI_SCHEDULED_DISPATCH__ = async function(js_event, js_env, js_ctx) { try { return await #{mod}.$dispatch_js(js_event, js_env, js_ctx); } catch (err) { try { globalThis.console.error('[Cloudflare::Scheduled] dispatch failed:', err && err.stack || err); } catch (e) {} return { error: String(err && err.message || err) }; } };`
+    end
+
+    # Called from the JS hook. Resolves the Ruby app, builds a
+    # ScheduledEvent, runs `dispatch_scheduled` on the app class, and
+    # returns the result Hash for diagnostics. We `__await__` the
+    # inner dispatch so the returned object is the resolved Hash, not
+    # a Promise — the JS hook then `await`s our return promise once.
+    def self.dispatch_js(js_event, js_env, js_ctx)
+      event = ScheduledEvent.from_js(js_event)
+      target = resolve_app
+      if target.nil?
+        warn '[Cloudflare::Scheduled] no app registered; ignoring scheduled event'
+        return { 'fired' => 0, 'total' => 0, 'results' => [], 'error' => 'no_app' }
+      end
+      target.dispatch_scheduled(event, js_env, js_ctx).__await__
+    end
+
+    # Test-friendly direct entry point. Lets `test/scheduled_smoke.rb`
+    # exercise the same dispatch logic without going through the JS
+    # hook. `cron` / `scheduled_time` are plain Ruby values. Returns
+    # the awaited result Hash (callers can still `__await__` the
+    # outer Promise — this method is async since it uses `__await__`).
+    def self.dispatch(cron, scheduled_time = Time.now, js_env = nil, js_ctx = nil)
+      event = ScheduledEvent.new(cron: cron, scheduled_time: scheduled_time)
+      target = resolve_app
+      raise 'no app registered for Cloudflare::Scheduled' if target.nil?
+      target.dispatch_scheduled(event, js_env, js_ctx).__await__
+    end
+
+    # Await a JS Promise from inside `# await: true` code without
+    # exposing the `__await__` keyword to callers. Re-throws Promise
+    # rejections as synchronous Ruby exceptions so callers can rescue.
+    # Sinatra::Scheduled uses this to bridge per-job exceptions out of
+    # the async block boundary.
+    #
+    # Implemented as `__await__` directly so Opal compiles this method
+    # itself as async — callers in `# await: true` files that do
+    # `await_promise(p)` get the resolved value back the same way they
+    # would from a bare `p.__await__`. Rejections re-throw as Ruby
+    # exceptions thanks to ES8 `await`'s built-in throw semantics.
+    def self.await_promise(promise)
+      promise.__await__
+    end
+
+    # Resolve which app class should receive the dispatch. Priority:
+    #   1. `Cloudflare::Scheduled.app = SomeApp`     (explicit override)
+    #   2. `Rack::Handler::CloudflareWorkers.app`    (set by `run app`)
+    # Returns the class itself (not an instance), because
+    # `dispatch_scheduled` is a class method on Sinatra apps.
+    def self.resolve_app
+      candidate = @app
+      if candidate.nil? && defined?(::Rack::Handler::CloudflareWorkers)
+        candidate = ::Rack::Handler::CloudflareWorkers.app
+      end
+      return nil if candidate.nil?
+      # Sinatra app classes respond to `dispatch_scheduled` (added by
+      # Sinatra::Scheduled). Plain Rack apps would be instances and
+      # lack the class method — we return them as-is and let the
+      # caller's `dispatch_scheduled` raise NoMethodError so the
+      # mistake is visible.
+      if candidate.respond_to?(:dispatch_scheduled)
+        candidate
+      elsif candidate.respond_to?(:class) && candidate.class.respond_to?(:dispatch_scheduled)
+        candidate.class
+      else
+        candidate
+      end
+    end
+  end
+end
+
+# Auto-install the JS dispatcher hook the moment this file is loaded.
+# Sinatra extensions are evaluated by the user code that comes after,
+# so the hook must be live before the first scheduled event arrives.
+Cloudflare::Scheduled.install_dispatcher

--- a/lib/sinatra/scheduled.rb
+++ b/lib/sinatra/scheduled.rb
@@ -1,0 +1,327 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+# await: true
+#
+# Phase 9 — Sinatra::Scheduled
+#
+# A Sinatra extension that adds a class-level `schedule` DSL so user
+# apps can register Cloudflare Workers Cron Trigger handlers in the
+# same file as the HTTP routes. Modelled after the `whenever` /
+# `sidekiq-cron` style of inline declaration but mapped to the
+# Cloudflare Workers `scheduled(event, env, ctx)` lifecycle.
+#
+#     class App < Sinatra::Base
+#       register Sinatra::Scheduled
+#
+#       schedule '*/5 * * * *', name: 'heartbeat' do |event|
+#         db = env['cloudflare.DB']
+#         db.execute_insert(
+#           'INSERT INTO heartbeats (cron, scheduled_at) VALUES (?, ?)',
+#           [event.cron, event.scheduled_time.to_i]
+#         ).__await__
+#       end
+#
+#       schedule '0 */1 * * *' do |event|
+#         # hourly cleanup
+#       end
+#     end
+#
+# Each `schedule` call appends a job to `App.scheduled_jobs`. When the
+# Workers runtime fires the cron trigger, `src/worker.mjs` invokes
+# `globalThis.__HOMURABI_SCHEDULED_DISPATCH__`, which is installed by
+# `Cloudflare::Scheduled.install_dispatcher` and forwards the event to
+# this extension's `dispatch_scheduled` class method.
+#
+# The dispatcher matches `event.cron` (the literal cron string from
+# `wrangler.toml [triggers] crons`) against each registered job's
+# pattern. Matching is exact-string by default — Cloudflare Workers
+# always passes back one of the cron strings declared in wrangler.toml,
+# never a derived expression — but a `match:` proc may be supplied for
+# fuzzy matching during local testing.
+#
+# Each block runs in a fresh anonymous Sinatra subclass instance so
+# `env`, `helpers`, `settings`, and `logger` are available. The block
+# receives a `Cloudflare::ScheduledEvent` argument exposing `.cron`,
+# `.scheduled_time` (Time), and `.type`.
+#
+# `wait_until(promise)` is a thin wrapper over the Workers
+# `ctx.waitUntil(...)` API so a job can hand back a long-running
+# promise without blocking the dispatcher.
+
+require 'time'
+
+module Sinatra
+  module Scheduled
+    # A registered scheduled job. Captured at class-definition time;
+    # the block is invoked once per matching cron firing.
+    #
+    # The block is held both as a Proc (for introspection and the
+    # unit tests that just call .block.call) and as an UnboundMethod
+    # bound onto a fresh ScheduledContext at fire time. The
+    # UnboundMethod path is what makes `__await__` inside the block
+    # actually await on the Workers runtime — Opal's `# await: true`
+    # mode promotes `define_method`'d methods to async functions, but
+    # NOT free-standing blocks called via `Proc#call` / `instance_exec`.
+    # Sinatra itself uses the same trick for its routes (see
+    # `Sinatra::Base.generate_method`).
+    class Job
+      attr_reader :cron, :name, :block, :unbound_method, :match_proc, :file, :line
+
+      def initialize(cron:, name:, block:, unbound_method: nil, match_proc: nil, file: nil, line: nil)
+        @cron = cron.to_s.freeze
+        @name = (name || cron).to_s.freeze
+        @block = block
+        @unbound_method = unbound_method
+        @match_proc = match_proc
+        @file = file
+        @line = line
+      end
+
+      # True when this job should fire for the given cron string.
+      # The default policy is exact string match, which is what the
+      # Workers runtime guarantees. A custom :match proc lets tests
+      # use loose matching (e.g. always run, regex match) without
+      # touching wrangler.toml.
+      def matches?(cron_string)
+        return @match_proc.call(cron_string) if @match_proc
+        @cron == cron_string.to_s
+      end
+    end
+
+    module ClassMethods
+      # Returns the (per-class) array of registered Job instances.
+      # Subclassing inherits the parent's jobs by reference — explicit
+      # `schedule` calls in the subclass append to its own private list
+      # so a subclass cannot mutate its parent's schedule.
+      def scheduled_jobs
+        @scheduled_jobs ||= []
+      end
+
+      # Register a cron block.
+      #
+      #   schedule '*/5 * * * *' do |event|
+      #     ...
+      #   end
+      #
+      # Options:
+      #   :name      — human label for logging (default: the cron string)
+      #   :match     — proc(cron_string) returning truthy if this job
+      #                should fire. Defaults to exact-string equality.
+      def schedule(cron, name: nil, match: nil, &block)
+        raise ArgumentError, 'schedule requires a block' unless block
+        cron_str = cron.to_s
+        raise ArgumentError, 'cron expression must be non-empty' if cron_str.empty?
+        # Cheap structural sanity-check: 5 or 6 whitespace-separated
+        # fields. Cloudflare allows the standard 5-field form.
+        fields = cron_str.split(/\s+/)
+        unless [5, 6].include?(fields.length)
+          raise ArgumentError, "cron expression must have 5 or 6 fields, got #{fields.length}: #{cron_str.inspect}"
+        end
+
+        loc = block.respond_to?(:source_location) ? block.source_location : nil
+        file = loc.is_a?(Array) ? loc[0] : nil
+        line = loc.is_a?(Array) ? loc[1] : nil
+
+        # Convert the block into an UnboundMethod bound to
+        # ScheduledContext. `define_method` is what triggers Opal's
+        # `# await: true` machinery to wrap the body as an async
+        # function — without this step, `kv.get(...).__await__` would
+        # never resolve because the surrounding scope isn't async.
+        # See the Job class comment for the full rationale.
+        method_name = "__scheduled_#{cron_str.object_id}_#{scheduled_jobs.length}".to_sym
+        ScheduledContext.send(:define_method, method_name, &block)
+        unbound = ScheduledContext.instance_method(method_name)
+        ScheduledContext.send(:remove_method, method_name)
+
+        scheduled_jobs << Job.new(
+          cron: cron_str,
+          name: name,
+          block: block,
+          unbound_method: unbound,
+          match_proc: match,
+          file: file,
+          line: line
+        )
+      end
+
+      # Returns all jobs that match the given cron string.
+      def scheduled_jobs_for(cron_string)
+        scheduled_jobs.select { |j| j.matches?(cron_string) }
+      end
+
+      # Dispatcher entry point — called by Cloudflare::Scheduled with
+      # a Cloudflare::ScheduledEvent and the JS env / ctx objects.
+      # Returns a Hash with `fired`, `total`, `errors` for diagnostics.
+      def dispatch_scheduled(event, js_env = nil, js_ctx = nil)
+        jobs = scheduled_jobs_for(event.cron)
+        results = []
+        i = 0
+        # `while` instead of `each` keeps the per-iteration begin/rescue
+        # straightforward under Opal's `# await: true` translation —
+        # each iteration's `__await__` is awaited inline rather than
+        # through a yielded async block (which has had subtle issues
+        # with rescue propagation in Opal).
+        while i < jobs.length
+          job = jobs[i]
+          start = Time.now.to_f
+          begin
+            # invoke_scheduled_job is an async method (it's defined
+            # inside a `# await: true` file and may itself await an
+            # inner Promise from the user block). Calling it returns
+            # a Promise — we MUST `__await__` it here so:
+            #   (a) downstream code sees fully-applied side effects,
+            #   (b) the rescue below catches Promise rejections that
+            #       propagate as Ruby exceptions.
+            #
+            # The literal `__await__` token is what Opal scans for to
+            # emit a JS `await`; calling a helper that internally does
+            # `__await__` is NOT enough, because the helper's return
+            # value is itself a Promise that the caller would have to
+            # `__await__` again.
+            promise = invoke_scheduled_job(job, event, js_env, js_ctx)
+            if `(#{promise} != null && typeof #{promise}.then === 'function')`
+              promise.__await__
+            end
+            results << {
+              'name'     => job.name,
+              'cron'     => job.cron,
+              'ok'       => true,
+              'duration' => Time.now.to_f - start
+            }
+          rescue ::Exception => e
+            results << {
+              'name'     => job.name,
+              'cron'     => job.cron,
+              'ok'       => false,
+              'error'    => "#{e.class}: #{e.message}",
+              'duration' => Time.now.to_f - start
+            }
+          end
+          i += 1
+        end
+        { 'fired' => results.size, 'total' => scheduled_jobs.size, 'results' => results }
+      end
+
+      private
+
+      # Build a tiny Rack-shaped env so the block has the same
+      # `env['cloudflare.DB']` / `KV` / `BUCKET` accessors that HTTP
+      # routes use. We deliberately do NOT spin up a full Sinatra
+      # request — there is no HTTP request, no params, no response.
+      def invoke_scheduled_job(job, event, js_env, js_ctx)
+        env = build_scheduled_env(event, js_env, js_ctx)
+        ctx = ScheduledContext.new(env, event, js_ctx)
+        # Prefer the UnboundMethod path (Opal `# await: true` aware).
+        # Fall back to instance_exec only when there is no unbound
+        # method — e.g. when a job was constructed manually in tests.
+        result = if job.unbound_method
+                   bound = job.unbound_method.bind(ctx)
+                   if job.block.arity.zero?
+                     bound.call
+                   else
+                     bound.call(event)
+                   end
+                 else
+                   ctx.instance_exec(event, &job.block)
+                 end
+        # When the block body uses `__await__` internally, Opal compiles
+        # the wrapping method as an async JS function, so its return
+        # value is a JS Promise. We MUST `await` that promise here for
+        # two reasons:
+        #
+        #   1. Side effects (D1 / KV writes) need to complete before
+        #      `dispatch_scheduled` records the job as `ok`.
+        #   2. Without the await, a `raise` inside the block silently
+        #      becomes a rejected promise and our outer `rescue` in
+        #      dispatch_scheduled never catches it — the bug would
+        #      surface as scheduled jobs reporting ok=true even when
+        #      they raised.
+        #
+        # Sync blocks return plain Ruby values; we use a JS-level
+        # thenable check before calling `.__await__` to avoid invoking
+        # the await on a non-Promise (which would crash).
+        if `(#{result} != null && typeof #{result}.then === 'function')`
+          # The literal `__await__` token is required at every async
+          # boundary — calling a helper that does `__await__` is NOT
+          # equivalent because the helper's return value is itself a
+          # Promise that callers would need to `__await__` again.
+          result.__await__
+        else
+          result
+        end
+      end
+
+      def build_scheduled_env(event, js_env, js_ctx)
+        env = {
+          'cloudflare.scheduled'      => true,
+          'cloudflare.event'          => event,
+          'cloudflare.cron'           => event.cron,
+          'cloudflare.scheduled_time' => event.scheduled_time,
+          'cloudflare.env'            => js_env,
+          'cloudflare.ctx'            => js_ctx
+        }
+        if js_env
+          js_db = `#{js_env} && #{js_env}.DB`
+          js_kv = `#{js_env} && #{js_env}.KV`
+          js_r2 = `#{js_env} && #{js_env}.BUCKET`
+          env['cloudflare.DB']     = ::Cloudflare::D1Database.new(js_db)  if `#{js_db} != null`
+          env['cloudflare.KV']     = ::Cloudflare::KVNamespace.new(js_kv) if `#{js_kv} != null`
+          env['cloudflare.BUCKET'] = ::Cloudflare::R2Bucket.new(js_r2)    if `#{js_r2} != null`
+        end
+        env
+      end
+    end
+
+    # ScheduledContext is the `self` inside a `schedule do ... end`
+    # block. It deliberately mirrors only the slice of Sinatra's
+    # request scope that makes sense outside an HTTP context: env,
+    # logger, settings, and Cloudflare binding helpers (db / kv /
+    # bucket).
+    class ScheduledContext
+      attr_reader :env, :event
+
+      def initialize(env, event, js_ctx)
+        @env = env
+        @event = event
+        @js_ctx = js_ctx
+      end
+
+      def db;     env['cloudflare.DB'];     end
+      def kv;     env['cloudflare.KV'];     end
+      def bucket; env['cloudflare.BUCKET']; end
+
+      # Forward a long-running promise to the Workers runtime so the
+      # job can return immediately while the work continues.
+      # Mirrors `ctx.waitUntil(promise)` in the JS API.
+      def wait_until(promise)
+        return promise if @js_ctx.nil?
+        js_ctx = @js_ctx
+        `#{js_ctx}.waitUntil(#{promise})`
+        promise
+      end
+
+      # Minimal logger so jobs can puts without crashing in non-Workers
+      # test environments. Falls back to STDOUT.
+      def logger
+        @logger ||= LoggerShim.new
+      end
+
+      class LoggerShim
+        %i[info warn error debug].each do |lvl|
+          define_method(lvl) { |msg| $stdout.puts("[scheduled.#{lvl}] #{msg}") }
+        end
+      end
+    end
+
+    # Sinatra calls registered(app) with the user's Sinatra::Base
+    # subclass when `register Sinatra::Scheduled` is evaluated.
+    def self.registered(app)
+      app.extend(ClassMethods)
+    end
+  end
+
+  # Auto-register on Sinatra::Base so plain `schedule` works for both
+  # classic-style and modular-style apps. Other Sinatra extensions
+  # (e.g. Sinatra::JwtAuth) follow the same convention.
+  Base.register Scheduled if defined?(::Sinatra::Base)
+end

--- a/lib/sinatra/scheduled.rb
+++ b/lib/sinatra/scheduled.rb
@@ -39,10 +39,13 @@
 # never a derived expression — but a `match:` proc may be supplied for
 # fuzzy matching during local testing.
 #
-# Each block runs in a fresh anonymous Sinatra subclass instance so
-# `env`, `helpers`, `settings`, and `logger` are available. The block
-# receives a `Cloudflare::ScheduledEvent` argument exposing `.cron`,
-# `.scheduled_time` (Time), and `.type`.
+# Each block runs in a fresh `ScheduledContext` instance (NOT a full
+# Sinatra subclass instance — there is no HTTP request, so Sinatra's
+# `request` / `response` / `params` are not available). Within the
+# block, the helpers exposed by ScheduledContext are: `env`,
+# `db` / `kv` / `bucket` (Cloudflare bindings), `event`, `wait_until`,
+# and `logger`. The block receives a `Cloudflare::ScheduledEvent`
+# argument exposing `.cron`, `.scheduled_time` (Time), and `.type`.
 #
 # `wait_until(promise)` is a thin wrapper over the Workers
 # `ctx.waitUntil(...)` API so a job can hand back a long-running
@@ -89,10 +92,12 @@ module Sinatra
     end
 
     module ClassMethods
-      # Returns the (per-class) array of registered Job instances.
-      # Subclassing inherits the parent's jobs by reference — explicit
-      # `schedule` calls in the subclass append to its own private list
-      # so a subclass cannot mutate its parent's schedule.
+      # Returns the per-class array of registered Job instances.
+      # Stored in a class instance variable, so subclasses do **not**
+      # inherit the parent's jobs unless that behavior is implemented
+      # explicitly (e.g. via an `inherited` hook copying the parent's
+      # `@scheduled_jobs`). The current behavior keeps each Sinatra
+      # subclass's schedule registry independent.
       def scheduled_jobs
         @scheduled_jobs ||= []
       end
@@ -116,6 +121,13 @@ module Sinatra
         fields = cron_str.split(/\s+/)
         unless [5, 6].include?(fields.length)
           raise ArgumentError, "cron expression must have 5 or 6 fields, got #{fields.length}: #{cron_str.inspect}"
+        end
+        # Fail loudly at registration time if a non-callable `match:`
+        # was passed — otherwise the failure would surface only when
+        # the cron actually fires (as a NoMethodError during dispatch),
+        # which is a much worse debugging experience.
+        if !match.nil? && !match.respond_to?(:call)
+          raise ArgumentError, "match: must respond to #call (got #{match.class})"
         end
 
         loc = block.respond_to?(:source_location) ? block.source_location : nil

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homurabi",
-  "version": "0.0.0-phase0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homurabi",
-      "version": "0.0.0-phase0",
+      "version": "1.0.0",
       "devDependencies": {
         "wrangler": "^3.99.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,14 +14,16 @@
     "test:workers": "bin/test-on-workers",
     "deploy": "npm run build && wrangler deploy",
     "build:test": "ruby bin/compile-erb && OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -r cloudflare_workers -r homurabi_templates -o build/smoke-test.mjs test/smoke.rb 2>build/opal.stderr.log",
-    "test": "npm run build:test && node --import ./src/setup-node-crypto.mjs build/smoke-test.mjs && npm run test:http && npm run test:crypto && npm run test:jwt",
+    "test": "npm run build:test && node --import ./src/setup-node-crypto.mjs build/smoke-test.mjs && npm run test:http && npm run test:crypto && npm run test:jwt && npm run test:scheduled",
     "build:http-test": "OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -o build/http-smoke.mjs test/http_smoke.rb 2>build/opal.stderr.log",
     "test:http": "npm run build:http-test && node --import ./src/setup-node-crypto.mjs build/http-smoke.mjs",
     "build:crypto-test": "OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -o build/crypto-smoke.mjs test/crypto_smoke.rb 2>build/opal.stderr.log",
     "test:crypto": "npm run build:crypto-test && node --import ./src/setup-node-crypto.mjs build/crypto-smoke.mjs",
     "build:jwt-test": "OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -o build/jwt-smoke.mjs test/jwt_smoke.rb 2>build/opal.stderr.log",
     "test:jwt": "npm run build:jwt-test && node --import ./src/setup-node-crypto.mjs build/jwt-smoke.mjs",
-    "clean": "rm -f build/hello.no-exit.mjs build/smoke-test.mjs build/http-smoke.mjs build/crypto-smoke.mjs build/jwt-smoke.mjs build/homurabi_templates.rb build/homurabi_assets.rb build/opal.stderr.log"
+    "build:scheduled-test": "OPAL_PREFORK_DISABLE=1 bundle exec opal -c -E --esm --no-source-map -I lib -I vendor -I build -r opal_patches -o build/scheduled-smoke.mjs test/scheduled_smoke.rb 2>build/opal.stderr.log",
+    "test:scheduled": "npm run build:scheduled-test && node --import ./src/setup-node-crypto.mjs build/scheduled-smoke.mjs",
+    "clean": "rm -f build/hello.no-exit.mjs build/smoke-test.mjs build/http-smoke.mjs build/crypto-smoke.mjs build/jwt-smoke.mjs build/scheduled-smoke.mjs build/homurabi_templates.rb build/homurabi_assets.rb build/opal.stderr.log"
   },
   "devDependencies": {
     "wrangler": "^3.99.0"

--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -46,4 +46,60 @@ export default {
 
     return dispatch(request, env, ctx, bodyText);
   },
+
+  // Phase 9 — Cloudflare Workers Cron Triggers entry point.
+  //
+  // The Workers runtime invokes this `scheduled` export once per
+  // matching `[triggers] crons` entry in wrangler.toml. We forward
+  // the (event, env, ctx) triple to the Ruby-side dispatcher
+  // installed by `lib/cloudflare_workers/scheduled.rb`
+  // (which registers `globalThis.__HOMURABI_SCHEDULED_DISPATCH__`).
+  //
+  // The Ruby dispatcher walks every job registered via the
+  // Sinatra DSL `schedule '*/5 * * * *' do ... end` and runs
+  // each one whose cron pattern matches `event.cron`.
+  //
+  // Local manual triggering (no cron poll wait):
+  //   wrangler dev --test-scheduled
+  //   curl 'http://127.0.0.1:8787/__scheduled?cron=*/5+*+*+*+*'
+  //
+  // Tip: ALWAYS call ctx.waitUntil on long-running work so the
+  // Workers runtime keeps the isolate alive past the dispatcher's
+  // synchronous return. The Ruby helper `wait_until(promise)` does
+  // exactly that.
+  async scheduled(event, env, ctx) {
+    const dispatch = globalThis.__HOMURABI_SCHEDULED_DISPATCH__;
+    if (typeof dispatch !== "function") {
+      // No Ruby dispatcher installed — the Opal bundle didn't
+      // require 'cloudflare_workers/scheduled'. Log loudly so this
+      // misconfiguration surfaces instead of silently dropping
+      // every cron firing.
+      try {
+        globalThis.console.error(
+          "homurabi: scheduled dispatcher not installed (require 'cloudflare_workers/scheduled' missing)",
+        );
+      } catch (e) {
+        // ignore — console may itself be broken in pathological cases
+      }
+      return;
+    }
+
+    // Hand the work to ctx.waitUntil so an async Ruby dispatcher
+    // (D1 writes, KV writes, fetch calls) can finish even though
+    // `scheduled` returns a Promise the runtime may not fully await
+    // on its own.
+    const work = (async () => {
+      try {
+        return await dispatch(event, env, ctx);
+      } catch (err) {
+        try {
+          globalThis.console.error("[scheduled] dispatcher threw:", err && err.stack || err);
+        } catch (e) {
+          // ignore
+        }
+      }
+    })();
+    ctx.waitUntil(work);
+    return work;
+  },
 };

--- a/test/scheduled_smoke.rb
+++ b/test/scheduled_smoke.rb
@@ -1,0 +1,422 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+# await: true
+#
+# Phase 9 — Scheduled Workers (Cron Triggers) smoke tests.
+#
+# Exercises the full dispatch chain that `src/worker.mjs#scheduled`
+# uses, but plugged into the test harness directly so we can run it
+# under Node without booting wrangler:
+#
+#   1. Sinatra::Scheduled DSL — `schedule '*/5 * * * *' do …`
+#      registers exactly one Job per call, with the right cron string,
+#      source location, and exact-string match policy.
+#   2. Multiple `schedule` calls on the same app accumulate (no
+#      shadowing).
+#   3. `dispatch_scheduled` only fires jobs whose cron equals
+#      `event.cron`; other jobs are skipped silently.
+#   4. The block runs inside a ScheduledContext that exposes the same
+#      `db` / `kv` / `bucket` helpers HTTP routes use (with whatever
+#      env wrappers the dispatcher built).
+#   5. `Cloudflare::Scheduled.dispatch(...)` — the test entry point —
+#      resolves the registered Sinatra app from
+#      `Rack::Handler::CloudflareWorkers.app` and forwards.
+#   6. `Cloudflare::ScheduledEvent.from_js` correctly converts the JS
+#      `event.scheduledTime` epoch-millis into a Ruby Time.
+#   7. Cron expression validation rejects malformed input loudly.
+#   8. Custom `match:` proc lets a job catch arbitrary cron strings
+#      (used for "always-run" test schedules).
+#   9. Block exceptions are caught per job and reported in the
+#      results array (one bad job doesn't kill the others).
+#
+# Usage:
+#   npm run test:scheduled
+#   npm test                # full suite (smoke + http + crypto + jwt + scheduled)
+
+require 'json'
+require 'time'
+require 'sinatra/base'
+require 'cloudflare_workers'
+require 'sinatra/scheduled'
+
+module SmokeTest
+  @passed = 0
+  @failed = 0
+  @errors = []
+
+  def self.assert(label, &block)
+    result = block.call
+    if result
+      @passed += 1
+      $stdout.puts "  PASS  #{label}"
+    else
+      @failed += 1
+      @errors << label
+      $stdout.puts "  FAIL  #{label}"
+    end
+  rescue Exception => e
+    @failed += 1
+    @errors << "#{label} (#{e.class}: #{e.message})"
+    $stdout.puts "  CRASH #{label} — #{e.class}: #{e.message}"
+  end
+
+  def self.report
+    total = @passed + @failed
+    $stdout.puts ''
+    $stdout.puts "#{total} tests, #{@passed} passed, #{@failed} failed"
+    if @errors.any?
+      $stdout.puts 'Failures:'
+      @errors.each { |e| $stdout.puts "  - #{e}" }
+    end
+    @failed == 0
+  end
+end
+
+# ---------------------------------------------------------------------
+# Test app — every test creates a fresh anonymous Sinatra subclass so
+# the `@scheduled_jobs` registry is isolated per case.
+# ---------------------------------------------------------------------
+def fresh_app
+  Class.new(Sinatra::Base) do
+    register Sinatra::Scheduled
+  end
+end
+
+# Each test below uses `app.dispatch_scheduled(...).__await__` to get
+# back the result Hash. The trailing `__await__` is required because
+# `dispatch_scheduled` is async (its inner per-job calls go through
+# Opal `# await: true`); without it, callers would inspect the
+# returned Promise instead of the resolved value. The literal
+# `__await__` token is what Opal scans for to emit a JS `await`.
+
+$stdout.puts '=== homurabi Phase 9 — Scheduled smoke ==='
+$stdout.puts ''
+
+# ---------------------------------------------------------------------
+# 1. DSL registration
+# ---------------------------------------------------------------------
+$stdout.puts '--- DSL registration ---'
+
+SmokeTest.assert('schedule registers exactly one job') {
+  app = fresh_app
+  app.schedule('*/5 * * * *') { |e| e }
+  app.scheduled_jobs.length == 1
+}
+
+SmokeTest.assert('schedule captures cron string verbatim') {
+  app = fresh_app
+  app.schedule('0 */1 * * *') { |e| e }
+  app.scheduled_jobs.first.cron == '0 */1 * * *'
+}
+
+SmokeTest.assert('schedule accepts :name option') {
+  app = fresh_app
+  app.schedule('*/5 * * * *', name: 'heartbeat') { |e| e }
+  app.scheduled_jobs.first.name == 'heartbeat'
+}
+
+SmokeTest.assert('schedule defaults :name to the cron string') {
+  app = fresh_app
+  app.schedule('*/5 * * * *') { |e| e }
+  app.scheduled_jobs.first.name == '*/5 * * * *'
+}
+
+SmokeTest.assert('multiple schedule calls accumulate (no shadowing)') {
+  app = fresh_app
+  app.schedule('*/5 * * * *') { |e| e }
+  app.schedule('0 */1 * * *') { |e| e }
+  app.schedule('0 0 * * *')   { |e| e }
+  app.scheduled_jobs.map(&:cron) == ['*/5 * * * *', '0 */1 * * *', '0 0 * * *']
+}
+
+# ---------------------------------------------------------------------
+# 2. Cron expression validation
+# ---------------------------------------------------------------------
+$stdout.puts ''
+$stdout.puts '--- Cron expression validation ---'
+
+SmokeTest.assert('schedule rejects empty cron string') {
+  app = fresh_app
+  raised = false
+  begin
+    app.schedule('') { |e| e }
+  rescue ArgumentError
+    raised = true
+  end
+  raised
+}
+
+SmokeTest.assert('schedule rejects 4-field cron expression (too few)') {
+  app = fresh_app
+  raised = false
+  begin
+    app.schedule('*/5 * * *') { |e| e }
+  rescue ArgumentError
+    raised = true
+  end
+  raised
+}
+
+SmokeTest.assert('schedule rejects 7-field cron expression (too many)') {
+  app = fresh_app
+  raised = false
+  begin
+    app.schedule('* * * * * * *') { |e| e }
+  rescue ArgumentError
+    raised = true
+  end
+  raised
+}
+
+SmokeTest.assert('schedule rejects no-block call') {
+  app = fresh_app
+  raised = false
+  begin
+    app.schedule('*/5 * * * *')
+  rescue ArgumentError
+    raised = true
+  end
+  raised
+}
+
+SmokeTest.assert('schedule accepts 6-field (with seconds) cron expression') {
+  app = fresh_app
+  app.schedule('0 */5 * * * *') { |e| e }
+  app.scheduled_jobs.first.cron == '0 */5 * * * *'
+}
+
+# ---------------------------------------------------------------------
+# 3. Dispatch — exact match
+# ---------------------------------------------------------------------
+$stdout.puts ''
+$stdout.puts '--- Dispatch: exact-string match ---'
+
+SmokeTest.assert('dispatch_scheduled fires only the matching job') {
+  app = fresh_app
+  fired = []
+  app.schedule('*/5 * * * *', name: 'a') { |e| fired << ['a', e.cron] }
+  app.schedule('0 */1 * * *', name: 'b') { |e| fired << ['b', e.cron] }
+
+  event = Cloudflare::ScheduledEvent.new(cron: '*/5 * * * *', scheduled_time: Time.now)
+  result = app.dispatch_scheduled(event).__await__
+
+  fired == [['a', '*/5 * * * *']] && result['fired'] == 1 && result['total'] == 2
+}
+
+SmokeTest.assert('dispatch_scheduled passes the ScheduledEvent into the block') {
+  app = fresh_app
+  captured = nil
+  app.schedule('*/5 * * * *') { |e| captured = e }
+  t = Time.at(1_700_000_000)
+  app.dispatch_scheduled(Cloudflare::ScheduledEvent.new(cron: '*/5 * * * *', scheduled_time: t)).__await__
+  captured.cron == '*/5 * * * *' && captured.scheduled_time.to_i == 1_700_000_000
+}
+
+SmokeTest.assert('dispatch_scheduled with no matching job returns fired=0') {
+  app = fresh_app
+  app.schedule('*/5 * * * *') { |e| e }
+  result = app.dispatch_scheduled(Cloudflare::ScheduledEvent.new(cron: 'nonexistent', scheduled_time: Time.now)).__await__
+  result['fired'] == 0 && result['total'] == 1
+}
+
+SmokeTest.assert('dispatch_scheduled records job name + ok=true on success') {
+  app = fresh_app
+  app.schedule('*/5 * * * *', name: 'heartbeat') { |e| e }
+  result = app.dispatch_scheduled(Cloudflare::ScheduledEvent.new(cron: '*/5 * * * *', scheduled_time: Time.now)).__await__
+  r = result['results'].first
+  r['name'] == 'heartbeat' && r['ok'] == true && r['cron'] == '*/5 * * * *'
+}
+
+# ---------------------------------------------------------------------
+# 4. ScheduledContext — db / kv / bucket helpers
+# ---------------------------------------------------------------------
+$stdout.puts ''
+$stdout.puts '--- ScheduledContext helpers ---'
+
+SmokeTest.assert('block self exposes #db / #kv / #bucket helpers') {
+  app = fresh_app
+  saw = {}
+  app.schedule('*/5 * * * *') do |_event|
+    saw[:db_method]     = respond_to?(:db)
+    saw[:kv_method]     = respond_to?(:kv)
+    saw[:bucket_method] = respond_to?(:bucket)
+    saw[:env_method]    = respond_to?(:env)
+  end
+  app.dispatch_scheduled(Cloudflare::ScheduledEvent.new(cron: '*/5 * * * *', scheduled_time: Time.now)).__await__
+  saw[:db_method] && saw[:kv_method] && saw[:bucket_method] && saw[:env_method]
+}
+
+SmokeTest.assert('block sees env[\'cloudflare.cron\']') {
+  app = fresh_app
+  seen = nil
+  app.schedule('*/5 * * * *') { |_e| seen = env['cloudflare.cron'] }
+  app.dispatch_scheduled(Cloudflare::ScheduledEvent.new(cron: '*/5 * * * *', scheduled_time: Time.now)).__await__
+  seen == '*/5 * * * *'
+}
+
+SmokeTest.assert('block sees env[\'cloudflare.scheduled\'] = true') {
+  app = fresh_app
+  seen = nil
+  app.schedule('*/5 * * * *') { |_e| seen = env['cloudflare.scheduled'] }
+  app.dispatch_scheduled(Cloudflare::ScheduledEvent.new(cron: '*/5 * * * *', scheduled_time: Time.now)).__await__
+  seen == true
+}
+
+SmokeTest.assert('db helper returns Cloudflare::D1Database wrapper when DB binding present') {
+  app = fresh_app
+  saw = nil
+  app.schedule('*/5 * * * *') { |_e| saw = db }
+
+  fake_db = `({ prepare: function(){} })`
+  fake_env = `({ DB: #{fake_db} })`
+  app.dispatch_scheduled(Cloudflare::ScheduledEvent.new(cron: '*/5 * * * *', scheduled_time: Time.now), fake_env).__await__
+  saw.is_a?(Cloudflare::D1Database)
+}
+
+SmokeTest.assert('kv helper returns Cloudflare::KVNamespace wrapper when KV binding present') {
+  app = fresh_app
+  saw = nil
+  app.schedule('*/5 * * * *') { |_e| saw = kv }
+  fake_kv = `({ get: function(){} })`
+  fake_env = `({ KV: #{fake_kv} })`
+  app.dispatch_scheduled(Cloudflare::ScheduledEvent.new(cron: '*/5 * * * *', scheduled_time: Time.now), fake_env).__await__
+  saw.is_a?(Cloudflare::KVNamespace)
+}
+
+# ---------------------------------------------------------------------
+# 5. ScheduledEvent.from_js — JS event conversion
+# ---------------------------------------------------------------------
+$stdout.puts ''
+$stdout.puts '--- ScheduledEvent.from_js ---'
+
+SmokeTest.assert('from_js converts cron + scheduledTime correctly') {
+  js_event = `({ cron: '*/5 * * * *', scheduledTime: 1700000000000, type: 'scheduled' })`
+  ev = Cloudflare::ScheduledEvent.from_js(js_event)
+  ev.cron == '*/5 * * * *' && ev.scheduled_time.to_i == 1_700_000_000 && ev.type == 'scheduled'
+}
+
+SmokeTest.assert('from_js handles missing scheduledTime by defaulting to now') {
+  js_event = `({ cron: '*/5 * * * *', type: 'scheduled' })`
+  ev = Cloudflare::ScheduledEvent.from_js(js_event)
+  ev.cron == '*/5 * * * *' && ev.scheduled_time.is_a?(Time)
+}
+
+# ---------------------------------------------------------------------
+# 6. Cloudflare::Scheduled.dispatch — public entry point
+# ---------------------------------------------------------------------
+$stdout.puts ''
+$stdout.puts '--- Cloudflare::Scheduled.dispatch ---'
+
+SmokeTest.assert('Scheduled.dispatch routes to the registered app') {
+  app = fresh_app
+  fired = []
+  app.schedule('*/5 * * * *') { |e| fired << e.cron }
+  Cloudflare::Scheduled.app = app
+  begin
+    Cloudflare::Scheduled.dispatch('*/5 * * * *', Time.now).__await__
+  ensure
+    Cloudflare::Scheduled.app = nil
+  end
+  fired == ['*/5 * * * *']
+}
+
+SmokeTest.assert('Scheduled.dispatch raises when no app is registered') {
+  Cloudflare::Scheduled.app = nil
+  if defined?(Rack::Handler::CloudflareWorkers)
+    begin
+      saved_app = Rack::Handler::CloudflareWorkers.instance_variable_get(:@app)
+      Rack::Handler::CloudflareWorkers.instance_variable_set(:@app, nil)
+    rescue StandardError
+      saved_app = nil
+    end
+  end
+  raised = false
+  begin
+    Cloudflare::Scheduled.dispatch('*/5 * * * *').__await__
+  rescue StandardError
+    raised = true
+  end
+  if defined?(Rack::Handler::CloudflareWorkers) && saved_app
+    Rack::Handler::CloudflareWorkers.instance_variable_set(:@app, saved_app)
+  end
+  raised
+}
+
+# ---------------------------------------------------------------------
+# 7. Custom :match proc
+# ---------------------------------------------------------------------
+$stdout.puts ''
+$stdout.puts '--- Custom :match proc ---'
+
+SmokeTest.assert(':match proc lets a job catch any cron expression') {
+  app = fresh_app
+  fired = []
+  app.schedule('* * * * *', match: ->(_cron) { true }) { |e| fired << e.cron }
+  app.dispatch_scheduled(Cloudflare::ScheduledEvent.new(cron: 'unrelated-cron', scheduled_time: Time.now)).__await__
+  fired == ['unrelated-cron']
+}
+
+SmokeTest.assert(':match proc returning false skips the job') {
+  app = fresh_app
+  fired = []
+  app.schedule('* * * * *', match: ->(_cron) { false }) { |e| fired << e.cron }
+  result = app.dispatch_scheduled(Cloudflare::ScheduledEvent.new(cron: '*/5 * * * *', scheduled_time: Time.now)).__await__
+  fired.empty? && result['fired'] == 0
+}
+
+# ---------------------------------------------------------------------
+# 8. Per-job error isolation
+# ---------------------------------------------------------------------
+$stdout.puts ''
+$stdout.puts '--- Per-job error isolation ---'
+
+SmokeTest.assert('an exception in one job does not stop sibling jobs') {
+  app = fresh_app
+  fired = []
+  app.schedule('*/5 * * * *', name: 'a') { |_e| raise 'kaboom' }
+  app.schedule('*/5 * * * *', name: 'b') { |_e| fired << :b }
+  result = app.dispatch_scheduled(Cloudflare::ScheduledEvent.new(cron: '*/5 * * * *', scheduled_time: Time.now)).__await__
+  ok_a = result['results'].find { |r| r['name'] == 'a' }
+  ok_b = result['results'].find { |r| r['name'] == 'b' }
+  fired == [:b] && ok_a['ok'] == false && ok_a['error'].include?('kaboom') && ok_b['ok'] == true
+}
+
+SmokeTest.assert('failed job records error class + message') {
+  app = fresh_app
+  app.schedule('*/5 * * * *') { |_e| raise ArgumentError, 'bad stuff' }
+  result = app.dispatch_scheduled(Cloudflare::ScheduledEvent.new(cron: '*/5 * * * *', scheduled_time: Time.now)).__await__
+  r = result['results'].first
+  r['ok'] == false && r['error'].include?('ArgumentError') && r['error'].include?('bad stuff')
+}
+
+# ---------------------------------------------------------------------
+# 9. JS dispatcher hook installation
+# ---------------------------------------------------------------------
+$stdout.puts ''
+$stdout.puts '--- JS dispatcher hook ---'
+
+SmokeTest.assert('globalThis.__HOMURABI_SCHEDULED_DISPATCH__ is installed') {
+  installed = `typeof globalThis.__HOMURABI_SCHEDULED_DISPATCH__ === 'function'`
+  installed
+}
+
+SmokeTest.assert('JS dispatcher hook resolves to the Sinatra app via Rack handler') {
+  # Plug a fresh app in via the explicit override and call the JS
+  # hook the way `src/worker.mjs#scheduled` would.
+  app = fresh_app
+  fired = []
+  app.schedule('*/5 * * * *', name: 'js-hook') { |e| fired << e.cron }
+  Cloudflare::Scheduled.app = app
+  result = nil
+  begin
+    js_event = `({ cron: '*/5 * * * *', scheduledTime: 1700000000000, type: 'scheduled' })`
+    promise = `globalThis.__HOMURABI_SCHEDULED_DISPATCH__(#{js_event}, null, null)`
+    result = promise.__await__
+  ensure
+    Cloudflare::Scheduled.app = nil
+  end
+  fired == ['*/5 * * * *'] && result['fired'] == 1
+}
+
+success = SmokeTest.report
+`process.exit(#{success ? 0 : 1})`

--- a/test/scheduled_smoke.rb
+++ b/test/scheduled_smoke.rb
@@ -185,6 +185,17 @@ SmokeTest.assert('schedule accepts 6-field (with seconds) cron expression') {
   app.scheduled_jobs.first.cron == '0 */5 * * * *'
 }
 
+SmokeTest.assert('schedule rejects non-callable match:') {
+  app = fresh_app
+  raised = false
+  begin
+    app.schedule('*/5 * * * *', match: 'not-a-proc') { |e| e }
+  rescue ArgumentError
+    raised = true
+  end
+  raised
+}
+
 # ---------------------------------------------------------------------
 # 3. Dispatch — exact match
 # ---------------------------------------------------------------------

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -45,11 +45,18 @@ HOMURABI_ENABLE_SCHEDULED_DEMOS = "0"
 # The schedules below mirror the demo `schedule` blocks in
 # `app/hello.rb`. Edit / extend in tandem when adding new jobs.
 #
+# Production safety: the demo schedule *bodies* in app/hello.rb
+# short-circuit to a no-op unless `HOMURABI_ENABLE_SCHEDULED_DEMOS`
+# is set to "1" (default-deny via the `[vars]` block above). Cron
+# firings still happen on every deploy — they just don't write to
+# D1 / KV unless the gate is open. To stop the firings entirely in
+# production, comment out / remove the `crons` entries below.
+#
 # To trigger manually in local dev:
 #   npx wrangler dev --test-scheduled
 #   curl 'http://127.0.0.1:8787/__scheduled?cron=*/5+*+*+*+*'
 [triggers]
 crons = [
-  "*/5 * * * *",   # heartbeat — writes a row to D1 every 5 minutes
-  "0 */1 * * *",   # hourly housekeeping — KV cleanup demo
+  "*/5 * * * *",   # heartbeat — writes a row to D1 every 5 minutes (gated)
+  "0 */1 * * *",   # hourly housekeeping — KV counter demo (gated)
 ]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -28,3 +28,28 @@ bucket_name = "homurabi-bucket"
 # CPU-DoS vector. Set to "1" only in dev or behind a private route.
 [vars]
 HOMURABI_ENABLE_CRYPTO_DEMOS = "0"
+# Phase 9: gating for the educational scheduled-introspection routes
+# (`/test/scheduled`, `/test/scheduled/run`). Default OFF — the run
+# endpoint manually fires every registered cron handler and could
+# write to D1 / KV from any unauthenticated caller in production.
+# Set to "1" only in dev or behind a private route.
+HOMURABI_ENABLE_SCHEDULED_DEMOS = "0"
+
+# Phase 9 — Cloudflare Workers Cron Triggers.
+#
+# Each entry below produces one `scheduled(event, env, ctx)` firing
+# per match. `event.cron` will literally be the string declared here,
+# so the Ruby `schedule '*/5 * * * *' do ... end` blocks match by
+# exact-string equality.
+#
+# The schedules below mirror the demo `schedule` blocks in
+# `app/hello.rb`. Edit / extend in tandem when adding new jobs.
+#
+# To trigger manually in local dev:
+#   npx wrangler dev --test-scheduled
+#   curl 'http://127.0.0.1:8787/__scheduled?cron=*/5+*+*+*+*'
+[triggers]
+crons = [
+  "*/5 * * * *",   # heartbeat — writes a row to D1 every 5 minutes
+  "0 */1 * * *",   # hourly housekeeping — KV cleanup demo
+]


### PR DESCRIPTION
## Summary

- New **`Sinatra::Scheduled`** extension provides a `schedule '*/5 * * * *' do |event| ... end` DSL that mirrors Sidekiq-Cron / whenever style declarations.
- New **`Cloudflare::Scheduled`** dispatcher hooks `globalThis.__HOMURABI_SCHEDULED_DISPATCH__` so `src/worker.mjs#scheduled(event, env, ctx)` forwards every cron firing into the registered Sinatra app.
- Demo cron jobs in `app/hello.rb`: heartbeat (5min → D1 INSERT) and hourly-housekeeping (1h → KV read-modify-write counter).
- Self-test routes `/test/scheduled` (lists registered jobs) + `/test/scheduled/run?cron=…` (manual fire), default-deny via `HOMURABI_ENABLE_SCHEDULED_DEMOS`.
- 29 new smoke tests bring the suite to **198 total, all green** (was 169 on Phase 8 main).

## What was hard

Opal's `# await: true` is **token-driven**: only the literal `__await__` token is rewritten to JS `await`. Calling a helper that internally does `__await__` returns a Promise the caller still has to await again. First cut used `instance_exec` for the user block — that worked for sync blocks but silently fire-and-forgot every D1/KV `.__await__` inside an async block, so cron jobs reported `ok: true` while their writes vanished. Fix: convert the block via `define_method` on `ScheduledContext`, then call via `unbound_method.bind(ctx).call(event)` — same trick `Sinatra::Base.generate_method` uses for HTTP routes. After that, every async boundary explicitly carries a literal `.__await__` (dispatcher → invoke_scheduled_job → bound block → `Cloudflare::Scheduled.dispatch_js`).

## Test plan

- [x] `npm test` — 27 + 14 + 85 + 43 + 29 = **198 tests, all passing**
- [x] `npm run build` — clean (5.6 MB bundle, ~6 KB delta vs Phase 8)
- [x] `npx wrangler dev --test-scheduled --local`
  - [x] `curl 'http://127.0.0.1:8787/__scheduled?cron=*/5+*+*+*+*'` → heartbeat D1 row appears
  - [x] `curl 'http://127.0.0.1:8787/__scheduled?cron=0+*/1+*+*+*'` → hourly KV counter increments
  - [x] 4 sequential hourly fires from a fresh KV → `count: 1→4` (read-modify-write proven)
  - [x] `/test/scheduled` lists both registered jobs
  - [x] `/test/scheduled/run?cron=99+*+*+*+*` returns `fired: 0` (no match)
- [x] `.artifacts/phase9-cron/REPORT.md` — full design notes, evidence, and "out of scope" deferrals

🤖 Generated with [Claude Code](https://claude.com/claude-code)