### PR TITLE
Phase 17: Email Sending via Cloudflare Email Service (SEND_EMAIL binding + Cloudflare::Email wrapper)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: gems/cloudflare-workers-runtime
   specs:
-    cloudflare-workers-runtime (0.1.0)
+    cloudflare-workers-runtime (0.1.1)
       opal (= 1.8.3.rc1)
 
 PATH

--- a/REPORT.md
+++ b/REPORT.md
@@ -115,7 +115,7 @@ curl -sS -b /tmp/p17-cookie.txt -X POST https://homurabi.kazu-san.workers.dev/de
   "cf_send_result_json": "{\"messageId\":\"<3bKVIsJnguzE9gjQt0BXP51yKwGwWRggFS33@kazuph-info.ai-work.uk>\"}",
   "to": "kazu.homma@gmail.com",
   "from": "noreply@kazuph-info.ai-work.uk",
-  "subject": "homurabi Phase 17 HTML CONFIRMATION (太字+リスト+リンク表示確認) — <CF-Ray suffix>"
+  "subject": "homurabi Phase 17 HTML CONFIRMATION (太字+リスト+リンク表示確認) — 9f00be87ee1dd534"
 }
 ```
 
@@ -133,3 +133,48 @@ curl -sS -b /tmp/p17-cookie.txt -X POST https://homurabi.kazu-san.workers.dev/de
 ```
 
 **マスターへ**: 件名に **HTML CONFIRMATION** と **太字+リスト+リンク** が含まれるメールで、Gmail でリッチ表示を確認してください。
+
+---
+
+## HTML が Gmail でレンダリングされなかった根本原因と修正（2026-04-22）
+
+参考: [Workers Email API — send](https://developers.cloudflare.com/email-service/api/send-emails/workers-api/)（`html` / `text` は任意組み合わせ・multipart）。
+
+### 原因（X）
+
+`build_send_payload` で `payload.subject` / `.text` / `.html` に **Opal の String オブジェクトをそのまま代入**していた。ランタイム上は `typeof payload.html === 'object'` となりうる。**Cloudflare Email の `binding.send(payload)` がプレーン JS の `string` を期待しているため、multipart の HTML 側が効かず text のみになっていた**。
+
+### 修正（Y）
+
+`gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb` で **`subject` / `text` / `html` 代入時に `.toString()`（JS の primitive string）へ正規化**した。
+
+### wrangler tail での実証（デバッグビルド / Version `d851aa61-0315-445c-9639-cf0d6b6a23e2`）
+
+`binding.send` 直前に一時的に `console.log` を入れたデプロイで `/debug/mail` を POST。`logs` に以下が記録された（要旨）:
+
+```json
+{
+  "subject_type": "string",
+  "text_type": "string",
+  "html_type": "string",
+  "subject_len": 75,
+  "text_len": 28,
+  "html_len": 384,
+  "html_head": "<h1 style=\\\"color:#f6821f;\\\">HTML 表示確認</h1>..."
+}
+```
+
+※ `html_head` は URL エンコードされたフォーム由来で `%3D` 等が混ざるが、**`html_type` が `"string"` であること**が物理的な根拠。
+
+### 修正後の本番デプロイ
+
+- **ログ除去後の Version ID**: `a58bbf47-f411-446b-b4f2-45169fa1b4a3`
+
+### 再送信（修正後・ログなしビルド）
+
+- **message_id**: `<Fjgso94lijW0Ipw9tOdd8SVCkLzlGTWOGGmt@kazuph-info.ai-work.uk>`
+- **件名**: `homurabi Phase 17 HTML CONFIRMATION (太字+リスト+リンク表示確認)`（末尾に CF-Ray 由来の短いサフィックスが付く場合あり）
+
+デバッグ送信時の message_id（同一修正コード・ログ付きビルド）: `<Jr6YtZkTkdrWbhlk9CP4ep5V1xhB0yrEfCPN@kazuph-info.ai-work.uk>`（HTTP 200）。
+
+**マスターへ**: 上記 **再送信分**（`Fjgso94li…`）で Gmail の HTML 表示を確認してください。届かない場合はスパム／セグメントを確認。

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,56 @@
+# Phase 17 — 本番実送信記録（Cursor）
+
+## 実送信タイムスタンプ（UTC）
+
+- **送信処理完了（HTTP 200）**: `2026-04-22T00:46:47Z`（メール本文 `Time:` フィールドと一致）
+
+## Workers Version（subject に使用）
+
+- **Version ID**: `a971976e-7f97-493a-b682-4a271621b45b`  
+  （`wrangler deployments list` の一覧末尾 = デプロイ Created `2026-04-22T00:32:27Z` 付近）
+
+## 認証
+
+- `POST https://homurabi.kazu-san.workers.dev/login` に `username=kazuph`（このアプリは同期ルートでパスワード検証なしでセッション発行）。
+- Cookie jar: `/tmp/p17-cookie.txt`（`homurabi_session`）。
+
+## 成功した POST（`/debug/mail`）
+
+- **形式**: `application/x-www-form-urlencoded`
+- **注意**: `--data-urlencode` で `to` を渡すと `@` が `%40` のまま API に届き **`E_VALIDATION_ERROR`（invalid recipient）** になるため、**`-d "to=kazu.homma@gmail.com"` のように素の `@` で送る**こと。
+
+### レスポンス JSON（本文 `<pre>` から復元）
+
+```json
+{
+  "ok": true,
+  "message_id": "<5TsIqnKxnOouoi7rr8sE9787e21VFiI1OyDR@kazuph-info.ai-work.uk>",
+  "cf_send_result_json": "{\"messageId\":\"<5TsIqnKxnOouoi7rr8sE9787e21VFiI1OyDR@kazuph-info.ai-work.uk>\"}",
+  "to": "kazu.homma@gmail.com",
+  "from": "noreply@kazuph-info.ai-work.uk",
+  "subject": "homurabi Phase 17 test — Version a971976e-7f97-493a-b682-4a271621b45b"
+}
+```
+
+- **message_id（短縮表示用）**: `<5TsIqnKxnOouoi7rr8sE9787e21VFiI1OyDR@kazuph-info.ai-work.uk>`
+
+### リクエスト本文（text）
+
+```
+This is a test mail from homurabi Phase 17 (Cloudflare Email Service public beta). Time: 2026-04-22T00:46:47Z
+```
+
+※ `from` フォーム値はアプリ側では未使用（`HOMURABI_MAIL_FROM` = `noreply@kazuph-info.ai-work.uk` が実送信元）。
+
+## 失敗試行（参考）
+
+1. **宛先**: `--data-urlencode to=...` → `kazu.homma%40gmail.com` となり Cloudflare API が「Missing domain or user」。
+2. **ログイン**: `curl -L` 追従で最終コードが 404 になることがあるが、**Set-Cookie は取得済み**のため `/debug/mail` にはセッション付きで到達可能。
+
+## wrangler tail
+
+- `wrangler tail homurabi` を短時間実行し、リクエスト JSON ログの先頭行が取得できることを確認（詳細ログはローカル環境依存）。
+
+---
+
+**マスターへ**: Gmail（`kazu.homma@gmail.com`）での着信確認をお願いします。件名は `homurabi Phase 17 test — Version a971976e-7f97-493a-b682-4a271621b45b` です。

--- a/REPORT.md
+++ b/REPORT.md
@@ -231,3 +231,52 @@ curl -sS -b /tmp/p17-cookie.txt -X POST https://homurabi.kazu-san.workers.dev/de
 `2026-04-22T01:43:34Z` 時点で `npm test` 全スイート PASS。
 
 **マスターへ**: 件名に **`Phase 17 refactor verification`** と **Version UUID** が含まれるメールで、Gmail で **HTML レンダリング**（オレンジ見出し・太字・コード表示）を確認してください。問題なければ Phase 17 マージ判断で構いません。
+
+---
+
+## Phase 17 URL decode 修正・本番検証（マスター承認デプロイ 1 回）
+
+### Workers Version ID（`wrangler deploy` 出力）
+
+`8d40afc4-e230-412f-9818-19b54e1762a8`
+
+※ 検証送信時に一時的に `binding.send(payload)` 直前へ **tail 用 console.log**（`html_has_literal_pct2f` / `html_has_closing_h1`）を入れたビルド。このデプロイで記録。**記録後、リポジトリからは tail ログ行を削除済み**（次回以降の deploy で本番ログがノイズフリーになる）。
+
+### POST `/debug/mail`（admin セッション）
+
+- **to**: `kazu.homma@gmail.com`
+- **subject（応答 JSON）**: `homurabi Phase 17 url-decode verification — 8d40afc4-e230-412f-9818-19b54e1762a8 — 9f00fedd39e69501`
+- **text**: `plain fallback`
+- **html**: ユーザー指定どおり（`<h1 style="color:#f6821f;">URL decode fix 検証</h1>` … リスト・リンク）
+
+### レスポンス JSON（復元）
+
+```json
+{
+  "message_id": "<Y2OFCCO7qCKmYcJFIh8oy1r3ZHBlzZS0mByQ@kazuph-info.ai-work.uk>",
+  "subject": "homurabi Phase 17 url-decode verification — 8d40afc4-e230-412f-9818-19b54e1762a8 — 9f00fedd39e69501"
+}
+```
+
+- **HTTP**: 200
+
+### wrangler tail（payload 直前）
+
+`homurabi_email_payload_probe`:
+
+```json
+{"homurabi_email_payload_probe":{"html_len":282,"html_has_literal_pct2f":false,"html_has_closing_h1":true}}
+```
+
+- **`html_has_literal_pct2f`: `false`** → binding に渡す **JS 文字列にリテラル `%2F` が残っていない**ことを確認。
+- **`html_has_closing_h1`: `true`** → **`</h1>` が実タグとして含まれる**ことを確認。
+
+### スモーク（本番 GET 12 ルート・HTTP 200）
+
+`/`, `/posts`, `/about`, `/login`, `/docs`, `/docs/email`, `/docs/quick-start`, `/docs/migration`, `/docs/sinatra`, `/docs/sequel-d1`, `/docs/runtime`, `/docs/architecture`
+
+### 検証時刻（UTC）
+
+`2026-04-22T01:54:13Z` 時点で deploy／POST／tail／12 ルート smoke 済み。
+
+**マスターへ**: 件名 **`Phase 17 url-decode verification`** で届いたメールで、本文が **`<%2Fh1>` 等のゴミなく** Gmail で HTML 表示されることを確認してください。（次に clean ログで本番へ再度反映する場合のみ、ログ除去済み HEAD を redeploy）

--- a/REPORT.md
+++ b/REPORT.md
@@ -54,3 +54,44 @@ This is a test mail from homurabi Phase 17 (Cloudflare Email Service public beta
 ---
 
 **マスターへ**: Gmail（`kazu.homma@gmail.com`）での着信確認をお願いします。件名は `homurabi Phase 17 test — Version a971976e-7f97-493a-b682-4a271621b45b` です。
+
+---
+
+## HTML + plain 複合送信（2026-04-22）
+
+- **デプロイ Version ID（wrangler deploy 出力）**: `6772a870-a1ea-4400-b8df-ff38f9e1a3a0`
+- **送信時刻（UTC, HTML に埋め込み）**: `2026-04-22T00:59:48Z`
+
+### curl 例（`html` は `--data-urlencode` で渡す）
+
+```bash
+curl -sS -b /tmp/p17-cookie.txt -X POST https://homurabi.kazu-san.workers.dev/debug/mail \
+  -d "to=kazu.homma@gmail.com" \
+  --data-urlencode "subject=homurabi Phase 17 HTML test — Version 6772a870-a1ea-4400-b8df-ff38f9e1a3a0" \
+  --data-urlencode "text=Plain text fallback (HTML 非対応クライアント用)" \
+  --data-urlencode "html=<h1>...</h1><p>...</p>"
+```
+
+※ 実際の応答では `subject` に CF-Ray 由来サフィックス（` — 9f00b0389a569160` 等）が付く場合あり（`/debug/mail` の既定ロジック）。
+
+### レスポンス JSON（復元）
+
+```json
+{
+  "ok": true,
+  "message_id": "<kH3DLrWLa83L2NfQTqYcP99yJfsDKQ9K2vPc@kazuph-info.ai-work.uk>",
+  "cf_send_result_json": "{\"messageId\":\"<kH3DLrWLa83L2NfQTqYcP99yJfsDKQ9K2vPc@kazuph-info.ai-work.uk>\"}",
+  "to": "kazu.homma@gmail.com",
+  "from": "noreply@kazuph-info.ai-work.uk",
+  "subject": "homurabi Phase 17 HTML test — Version 6772a870-a1ea-4400-b8df-ff38f9e1a3a0 — 9f00b0389a569160"
+}
+```
+
+### Plain text のみ（回帰）
+
+- **subject**: `Phase17 plain-only smoke`
+- **message_id**: `<wEpgiTbXQed97aTYRqdZo9YRn8b40noTwIWG@kazuph-info.ai-work.uk>` （HTTP 200、`ok: true`）
+
+---
+
+**マスターへ（HTML メール）**: Gmail でマルチパート（plain + HTML）の表示を確認してください。件名キーワード `Phase 17 HTML test`。

--- a/REPORT.md
+++ b/REPORT.md
@@ -178,3 +178,56 @@ curl -sS -b /tmp/p17-cookie.txt -X POST https://homurabi.kazu-san.workers.dev/de
 デバッグ送信時の message_id（同一修正コード・ログ付きビルド）: `<Jr6YtZkTkdrWbhlk9CP4ep5V1xhB0yrEfCPN@kazuph-info.ai-work.uk>`（HTTP 200）。
 
 **マスターへ**: 上記 **再送信分**（`Fjgso94li…`）で Gmail の HTML 表示を確認してください。届かない場合はスパム／セグメントを確認。
+
+---
+
+## Phase 17 リファクタ承認後・本番 HTML+text 再送信（2026-04-22）
+
+### Git / デプロイ整合性
+
+- **リポジトリ**: `4b67c65`（fragments dedent までのリファクタ列）は **現在の `HEAD` の祖先**（`merge-base --is-ancestor 4b67c65 HEAD` が真）。
+- **実送信時の Workers Version ID**（`wrangler deploy` 出力）: `7ccb9d4f-a98d-4281-aad7-5d8460f2b388`
+- **ログプローブ除去後の本番 Version ID**（現行トラフィック想定）: `1412a612-e397-4f9d-b090-122177aa91c0`
+
+### POST `/debug/mail`（admin セッション・multipart）
+
+- **to**: `kazu.homma@gmail.com`（`-d "to=..."` で素の `@`）
+- **subject（意図）**: `homurabi Phase 17 refactor verification — 7ccb9d4f-a98d-4281-aad7-5d8460f2b388`  
+  ※ **応答 JSON 上の subject** には既存ロジックにより **CF-Ray 由来の短いサフィックス**（例: ` — 9f00eb76cc9b80f0`）が **追加**される場合あり。
+- **text**: `Refactor 後の plain fallback`
+- **html**: `<h1 style="color:#f6821f;">` … `Homurabi::DebugMailController` …（スタイル付きブロック全文は送信時と同一）
+
+### レスポンス JSON（復元）
+
+```json
+{
+  "ok": true,
+  "message_id": "<LFz7G3g9vfNv5rXP8HbMMqZMmpXBovSBUEYJ@kazuph-info.ai-work.uk>",
+  "cf_send_result_json": "{\"messageId\":\"<LFz7G3g9vfNv5rXP8HbMMqZMmpXBovSBUEYJ@kazuph-info.ai-work.uk>\"}",
+  "to": "kazu.homma@gmail.com",
+  "from": "noreply@kazuph-info.ai-work.uk",
+  "subject": "homurabi Phase 17 refactor verification — 7ccb9d4f-a98d-4281-aad7-5d8460f2b388 — 9f00eb76cc9b80f0"
+}
+```
+
+- **HTTP**: 200（送信処理完了）
+
+### wrangler tail（`binding.send(payload)` 直前・型・長さのみ）
+
+一時的に `Cloudflare::Email` の async IIFE 内で `console.log(JSON.stringify({ homurabi_send_email_payload: … }))` を挿入したビルド **Version `bfb904b8-5fc7-4297-8ee4-29fa8557312d`** で `/debug/mail` を POST。`logs` に以下が記録された（**`html_type` が `"string"`** であることが multipart 経路の物理的根拠）:
+
+```json
+{"homurabi_send_email_payload":{"html_type":"string","text_type":"string","subject_type":"string","html_len":217,"text_len":10}}
+```
+
+※ 上記プローブ行は **記録後にコードから除去**し、**Version `1412a612-e397-4f9d-b090-122177aa91c0`** を再デプロイ済み（本番はログノイズなし）。
+
+### スモーク（本番 GET 11 ルート・HTTP 200）
+
+`/`, `/posts`, `/about`, `/login`, `/docs`, `/docs/email`, `/docs/quick-start`, `/docs/migration`, `/docs/sinatra`, `/docs/sequel-d1`, `/docs/runtime`, `/docs/architecture`
+
+### 検証時刻（UTC）
+
+`2026-04-22T01:43:34Z` 時点で `npm test` 全スイート PASS。
+
+**マスターへ**: 件名に **`Phase 17 refactor verification`** と **Version UUID** が含まれるメールで、Gmail で **HTML レンダリング**（オレンジ見出し・太字・コード表示）を確認してください。問題なければ Phase 17 マージ判断で構いません。

--- a/REPORT.md
+++ b/REPORT.md
@@ -95,3 +95,41 @@ curl -sS -b /tmp/p17-cookie.txt -X POST https://homurabi.kazu-san.workers.dev/de
 ---
 
 **マスターへ（HTML メール）**: Gmail でマルチパート（plain + HTML）の表示を確認してください。件名キーワード `Phase 17 HTML test`。
+
+---
+
+## HTML CONFIRMATION 送信（明示的な件名・スタイル確認用）
+
+**ドキュメント準拠**: `to` は **素の `@`**（`-d "to=..."`）。`html` / `text` / `subject` は **`--data-urlencode`** または **`--data-urlencode html@ファイル`**（長い HTML をシェルで壊さない）。
+
+- **送信時刻（UTC 概算）**: 実実行直後（Cloudflare 応答 HTTP 200）
+- **件名（意図）**: `homurabi Phase 17 HTML CONFIRMATION (太字+リスト+リンク表示確認)`  
+  ※ form-urlencoded により Cloudflare 応答 JSON 上は `+` が `%2B` 表記になることがある（受信側は通常デコードされる）。
+
+### レスポンス JSON（復元）
+
+```json
+{
+  "ok": true,
+  "message_id": "<3bKVIsJnguzE9gjQt0BXP51yKwGwWRggFS33@kazuph-info.ai-work.uk>",
+  "cf_send_result_json": "{\"messageId\":\"<3bKVIsJnguzE9gjQt0BXP51yKwGwWRggFS33@kazuph-info.ai-work.uk>\"}",
+  "to": "kazu.homma@gmail.com",
+  "from": "noreply@kazuph-info.ai-work.uk",
+  "subject": "homurabi Phase 17 HTML CONFIRMATION (太字+リスト+リンク表示確認) — <CF-Ray suffix>"
+}
+```
+
+- **text**: `これは HTML メールの fallback 文字列です`
+- **html**: スタイル付き `<h1>` / `<strong>` / `<em>` / `<ul>` / `<a href="https://homurabi.kazu-san.workers.dev/docs/email">` 等（長文は `/tmp/homurabi-html-confirmation.txt` に保存して `html@` で POST）。
+
+### curl 例
+
+```bash
+curl -sS -b /tmp/p17-cookie.txt -X POST https://homurabi.kazu-san.workers.dev/debug/mail \
+  -d "to=kazu.homma@gmail.com" \
+  --data-urlencode "subject=homurabi Phase 17 HTML CONFIRMATION (太字+リスト+リンク表示確認)" \
+  --data-urlencode "text=これは HTML メールの fallback 文字列です" \
+  --data-urlencode "html@/tmp/homurabi-html-confirmation.txt"
+```
+
+**マスターへ**: 件名に **HTML CONFIRMATION** と **太字+リスト+リンク** が含まれるメールで、Gmail でリッチ表示を確認してください。

--- a/app/app.rb
+++ b/app/app.rb
@@ -34,6 +34,7 @@ require 'sequel'
 
 require_relative 'helpers/session_cookie'
 require_relative 'helpers/chat_history'
+require_relative 'helpers/debug_mail'
 require_relative 'helpers/markdown_render'
 
 class App < Sinatra::Base
@@ -164,7 +165,11 @@ class App < Sinatra::Base
   SESSION_COOKIE_TTL  = 86_400
   SESSION_COOKIE_NAME = 'homurabi_session'
 
+  # Phase 17 — production /debug/mail gate (session username must match).
+  DEBUG_MAIL_ADMIN_USERNAME = 'kazuph'
+
   include Homurabi::SessionCookieInstanceMethods
+  helpers Homurabi::DebugMailHelpers
 
   # GET /login — simple demo login form. Any non-empty username
   # mints an HMAC-signed session cookie carrying `username:exp`.

--- a/app/app.rb
+++ b/app/app.rb
@@ -35,6 +35,7 @@ require 'sequel'
 require_relative 'helpers/session_cookie'
 require_relative 'helpers/chat_history'
 require_relative 'helpers/debug_mail'
+require_relative 'lib/debug_mail_controller'
 require_relative 'helpers/markdown_render'
 
 class App < Sinatra::Base

--- a/app/helpers/chat_history.rb
+++ b/app/helpers/chat_history.rb
@@ -45,6 +45,17 @@ module Homurabi
       env['cloudflare.QUEUE_JOBS_DLQ']
     end
 
+    def send_email
+      env['cloudflare.SEND_EMAIL']
+    end
+
+    # Phase 17 — verified sender after Cloudflare Email Service domain onboarding (`wrangler.toml` [vars]).
+    def homurabi_mail_from
+      cf_env = env['cloudflare.env']
+      return '' unless cf_env
+      `(#{cf_env}.HOMURABI_MAIL_FROM || '')`.to_s.strip
+    end
+
     def cache_get(cache_key, ttl: 60, content_type_override: nil, &block)
       raise ArgumentError, 'cache_get requires a block' unless block
       cache_ttl = ttl.to_i

--- a/app/helpers/debug_mail.rb
+++ b/app/helpers/debug_mail.rb
@@ -1,6 +1,8 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 
+require 'uri'
+
 module Homurabi
   # Phase 17 — `/debug/mail` is open on localhost only; deployed Workers require session user App::DEBUG_MAIL_ADMIN_USERNAME.
   #
@@ -9,6 +11,16 @@ module Homurabi
   # `throw :halt` does not reliably cross Opal/async boundaries (same rationale as avoiding
   # bare `redirect` in async-sensitive routes documented elsewhere in this repo).
   module DebugMailHelpers
+    # application/x-www-form-urlencoded 相当: `+` → space、`%xx` → 文字（decodeURIComponent 相当）。
+    # Opal 上で Sinatra/Rack の params に `%2F` が残り `<%2Fh1>` になる場合の保険。
+    # 既に `/` まで decode 済みの値は URI 実装によりほぼそのまま返る。
+    def self.www_decode(s)
+      s = s.to_s
+      URI.decode_www_form_component(s.tr('+', ' '))
+    rescue StandardError
+      s
+    end
+
     def debug_mail_local_request?
       h = request.host.to_s
       h == '127.0.0.1' || h == 'localhost'

--- a/app/helpers/debug_mail.rb
+++ b/app/helpers/debug_mail.rb
@@ -2,23 +2,27 @@
 # frozen_string_literal: true
 
 module Homurabi
-  # Phase 17 — `/debug/mail` is open on localhost only; deployed Workers require session user kazuph.
+  # Phase 17 — `/debug/mail` is open on localhost only; deployed Workers require session user App::DEBUG_MAIL_ADMIN_USERNAME.
   module DebugMailHelpers
     def debug_mail_local_request?
       h = request.host.to_s
       h == '127.0.0.1' || h == 'localhost'
     end
 
-    def debug_mail_require_kazuph!
-      return if debug_mail_local_request?
+    # Returns a Rack triple [status, headers, body] when access must be denied, else nil.
+    def debug_mail_gate_response
+      return nil if debug_mail_local_request?
+      return nil if current_session_user.to_s == App::DEBUG_MAIL_ADMIN_USERNAME
 
-      halt 403, debug_mail_forbidden_body unless current_session_user.to_s == App::DEBUG_MAIL_ADMIN_USERNAME
+      body_str = debug_mail_forbidden_body
+      [403, { 'Content-Type' => 'text/html; charset=utf-8', 'Content-Length' => body_str.bytesize.to_s }, [body_str]]
     end
 
     private
 
     def debug_mail_forbidden_body
-      '<!DOCTYPE html><html lang="ja"><meta charset="utf-8"><title>403 Forbidden</title><body><p>/debug/mail はデプロイ環境ではログインユーザー <code>kazuph</code> のみが利用できます（<a href="/login">ログイン</a>）。</p></body></html>'
+      u = App::DEBUG_MAIL_ADMIN_USERNAME
+      '<!DOCTYPE html><html lang="ja"><meta charset="utf-8"><title>403 Forbidden</title><body><p>/debug/mail はデプロイ環境ではログインユーザー <code>' + u.to_s + '</code> のみが利用できます（<a href="/login">ログイン</a>）。</p></body></html>'
     end
   end
 end

--- a/app/helpers/debug_mail.rb
+++ b/app/helpers/debug_mail.rb
@@ -3,6 +3,11 @@
 
 module Homurabi
   # Phase 17 — `/debug/mail` is open on localhost only; deployed Workers require session user App::DEBUG_MAIL_ADMIN_USERNAME.
+  #
+  # Gate uses `#debug_mail_gate_response` returning a Rack triple `[403, headers, [body]]`;
+  # routes use `gate = …; next gate if gate`. Sinatra `halt` is intentionally not used:
+  # `throw :halt` does not reliably cross Opal/async boundaries (same rationale as avoiding
+  # bare `redirect` in async-sensitive routes documented elsewhere in this repo).
   module DebugMailHelpers
     def debug_mail_local_request?
       h = request.host.to_s

--- a/app/helpers/debug_mail.rb
+++ b/app/helpers/debug_mail.rb
@@ -1,0 +1,24 @@
+# await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
+# frozen_string_literal: true
+
+module Homurabi
+  # Phase 17 — `/debug/mail` is open on localhost only; deployed Workers require session user kazuph.
+  module DebugMailHelpers
+    def debug_mail_local_request?
+      h = request.host.to_s
+      h == '127.0.0.1' || h == 'localhost'
+    end
+
+    def debug_mail_require_kazuph!
+      return if debug_mail_local_request?
+
+      halt 403, debug_mail_forbidden_body unless current_session_user.to_s == App::DEBUG_MAIL_ADMIN_USERNAME
+    end
+
+    private
+
+    def debug_mail_forbidden_body
+      '<!DOCTYPE html><html lang="ja"><meta charset="utf-8"><title>403 Forbidden</title><body><p>/debug/mail はデプロイ環境ではログインユーザー <code>kazuph</code> のみが利用できます（<a href="/login">ログイン</a>）。</p></body></html>'
+    end
+  end
+end

--- a/app/helpers/debug_mail.rb
+++ b/app/helpers/debug_mail.rb
@@ -26,8 +26,7 @@ module Homurabi
     private
 
     def debug_mail_forbidden_body
-      u = App::DEBUG_MAIL_ADMIN_USERNAME
-      '<!DOCTYPE html><html lang="ja"><meta charset="utf-8"><title>403 Forbidden</title><body><p>/debug/mail はデプロイ環境ではログインユーザー <code>' + u.to_s + '</code> のみが利用できます（<a href="/login">ログイン</a>）。</p></body></html>'
+      '<!DOCTYPE html><html lang="ja"><meta charset="utf-8"><title>403 Forbidden</title><body><p>Forbidden.</p></body></html>'
     end
   end
 end

--- a/app/lib/debug_mail_controller.rb
+++ b/app/lib/debug_mail_controller.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+# await: true
+#
+# Phase 17 — `/debug/mail` の送信・件名生成・結果 JSON 組み立て（ルート本体から分離）。
+
+require 'json'
+
+module Homurabi
+  module DebugMailController
+    class << self
+      DEFAULT_TO = 'kazu.homma@gmail.com'
+
+      SUBJECT_HAS_FULL_VERSION =
+        /homurabi Phase 17 test.{0,3}Version\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+
+      def parse_form_params(params, default_to: false)
+        to = params['to'].to_s.strip
+        to = DEFAULT_TO if default_to && to.empty?
+        {
+          to: to,
+          subject: sanitize_form(params['subject'].to_s.strip),
+          text: sanitize_form(params['text'].to_s),
+          html: sanitize_form(params['html'].to_s)
+        }
+      end
+
+      def send_test_mail(params, env, route)
+        form = parse_form_params(params, default_to: false)
+        mail_from = route.homurabi_mail_from
+        final_to = form[:to].empty? ? DEFAULT_TO : form[:to]
+
+        if mail_from.empty?
+          return error_result(form, mail_from, nil, 'HOMURABI_MAIL_FROM が未設定です。ドメイン onboarding 後に wrangler [vars] で verified の送信元アドレスを設定してください。')
+        end
+
+        mail = route.send_email
+        if mail.nil? || !mail.available?
+          return error_result(form, mail_from, nil, 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。')
+        end
+
+        vid = vid_from_env(env)
+        subject_line = resolve_subject_line(form[:subject], vid)
+        text_body, html_body = resolve_bodies(form[:text], form[:html])
+
+        dispatch_send(mail, form, mail_from, final_to, subject_line, text_body, html_body)
+      end
+
+      private
+
+      def sanitize_form(value)
+        value.tr('+', ' ')
+      end
+
+      def vid_from_env(env)
+        ray = env['HTTP_CF_RAY'].to_s.split('-').first
+        ray.nil? || ray.empty? ? Time.now.to_i.to_s : ray
+      end
+
+      def resolve_subject_line(form_subject, vid)
+        fs = form_subject.strip
+        return "homurabi Phase 17 test — #{vid}" if fs.empty?
+        return fs if fs =~ SUBJECT_HAS_FULL_VERSION
+
+        "#{fs} — #{vid}"
+      end
+
+      def resolve_bodies(form_text, form_html)
+        html = form_html.strip.empty? ? nil : form_html
+        text = if form_text.strip.empty?
+                 html ? nil : 'This is a test mail from homurabi'
+               else
+                 form_text
+               end
+        [text, html]
+      end
+
+      def dispatch_send(mail, form, mail_from, final_to, subject_line, text_body, html_body)
+        raw = mail.send(
+          to: final_to,
+          from: mail_from,
+          subject: subject_line,
+          text: text_body,
+          html: html_body
+        ).__await__
+
+        if `(#{raw} == null || #{raw} === undefined || #{raw} === Opal.nil)`
+          return error_result(form, mail_from, subject_line, 'SEND_EMAIL.send の戻りが null です。メールは送信されていません。')
+        end
+
+        message_id = extract_message_id(raw)
+        cf_raw = extract_cf_raw(raw)
+        success_result(form, mail_from, final_to, subject_line, message_id, cf_raw)
+      rescue Cloudflare::Email::Error => e
+        code = e.code.to_s
+        error_result(form, mail_from, subject_line, "#{code}: #{e.message}".strip)
+      end
+
+      def extract_message_id(result)
+        return '' unless result.respond_to?(:[])
+
+        result['message_id'].to_s.strip
+      end
+
+      def extract_cf_raw(result)
+        return '' unless result.respond_to?(:[])
+
+        result['cf_send_result_json'].to_s
+      end
+
+      def success_result(form, mail_from, final_to, subject_line, message_id, cf_raw)
+        accepted = !message_id.strip.empty?
+        warning =
+          if accepted
+            nil
+          else
+            'message_id が空です。cf_send_result_json を確認してください。送信はキューに載っていない可能性があります。'
+          end
+
+        payload = {
+          'ok' => accepted,
+          'message_id' => message_id,
+          'cf_send_result_json' => cf_raw,
+          'to' => final_to,
+          'from' => mail_from,
+          'subject' => subject_line
+        }
+        payload['warning'] = warning if warning
+
+        {
+          ok: accepted,
+          error: nil,
+          warning: warning,
+          message_id: message_id,
+          raw_json: JSON.generate(payload),
+          form: form,
+          mail_from: mail_from
+        }
+      end
+
+      def error_result(form, mail_from, subject_line, message)
+        h = {
+          ok: false,
+          error: message,
+          warning: nil,
+          message_id: nil,
+          raw_json: nil,
+          form: form,
+          mail_from: mail_from
+        }
+        h[:meta] = { subject_line: subject_line } if subject_line
+        h
+      end
+    end
+  end
+end

--- a/app/lib/debug_mail_controller.rb
+++ b/app/lib/debug_mail_controller.rb
@@ -4,6 +4,7 @@
 # Opal は `# await:` ブロック外のヘルパー内では `.__await__` が Promise を解決しない)。
 
 require 'json'
+require 'uri'
 
 module Homurabi
   module DebugMailController
@@ -76,8 +77,28 @@ module Homurabi
 
       private
 
+      # application/x-www-form-urlencoded 由来の `+` と、ツール連発などで混入しがちな
+      # 「閉じタグだけ %2F のまま」「:: が %3A%3A」のような **残留パーセントエンコード**を緩く直す。
+      # 完全なデコードは Rack が担当。ここでは最大 2 周だけ（decode 不能なら原文のまま）。
       def sanitize_form(value)
-        value.tr('+', ' ')
+        s = value.to_s.tr('+', ' ')
+        decode_percent_runaway(s)
+      end
+
+      def decode_percent_runaway(s)
+        return s unless s.include?('%')
+        out = s
+        2.times do
+          break unless /%[0-9A-Fa-f]{2}/.match?(out)
+          begin
+            d = URI.decode_www_form_component(out)
+            break if d == out
+            out = d
+          rescue ArgumentError, URI::InvalidURIError
+            break
+          end
+        end
+        out
       end
 
       def vid_from_env(env)

--- a/app/lib/debug_mail_controller.rb
+++ b/app/lib/debug_mail_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-# await: true
 #
-# Phase 17 — `/debug/mail` の送信・件名生成・結果 JSON 組み立て（ルート本体から分離）。
+# Phase 17 — `/debug/mail` の送信準備・結果整形（実際の `mail.send.__await__` はルート本体に置く。
+# Opal は `# await:` ブロック外のヘルパー内では `.__await__` が Promise を解決しない)。
 
 require 'json'
 
@@ -24,25 +24,54 @@ module Homurabi
         }
       end
 
-      def send_test_mail(params, env, route)
+      # バリデーション済みコンテキスト。`:error_result` があれば送信しない。
+      def prepare_send(params, env, route)
         form = parse_form_params(params, default_to: false)
         mail_from = route.homurabi_mail_from
         final_to = form[:to].empty? ? DEFAULT_TO : form[:to]
 
         if mail_from.empty?
-          return error_result(form, mail_from, nil, 'HOMURABI_MAIL_FROM が未設定です。ドメイン onboarding 後に wrangler [vars] で verified の送信元アドレスを設定してください。')
+          return { error_result: error_result(form, mail_from, nil, 'HOMURABI_MAIL_FROM が未設定です。ドメイン onboarding 後に wrangler [vars] で verified の送信元アドレスを設定してください。') }
         end
 
         mail = route.send_email
         if mail.nil? || !mail.available?
-          return error_result(form, mail_from, nil, 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。')
+          return { error_result: error_result(form, mail_from, nil, 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。') }
         end
 
         vid = vid_from_env(env)
         subject_line = resolve_subject_line(form[:subject], vid)
         text_body, html_body = resolve_bodies(form[:text], form[:html])
 
-        dispatch_send(mail, form, mail_from, final_to, subject_line, text_body, html_body)
+        {
+          mail: mail,
+          form: form,
+          mail_from: mail_from,
+          final_to: final_to,
+          subject_line: subject_line,
+          text_body: text_body,
+          html_body: html_body
+        }
+      end
+
+      def after_send_success(raw, ctx)
+        form = ctx[:form]
+        mail_from = ctx[:mail_from]
+        final_to = ctx[:final_to]
+        subject_line = ctx[:subject_line]
+
+        if `(#{raw} == null || #{raw} === undefined || #{raw} === Opal.nil)`
+          return error_result(form, mail_from, subject_line, 'SEND_EMAIL.send の戻りが null です。メールは送信されていません。')
+        end
+
+        message_id = extract_message_id(raw)
+        cf_raw = extract_cf_raw(raw)
+        success_result(form, mail_from, final_to, subject_line, message_id, cf_raw)
+      end
+
+      def after_send_failure(error, ctx)
+        code = error.code.to_s
+        error_result(ctx[:form], ctx[:mail_from], ctx[:subject_line], "#{code}: #{error.message}".strip)
       end
 
       private
@@ -72,27 +101,6 @@ module Homurabi
                  form_text
                end
         [text, html]
-      end
-
-      def dispatch_send(mail, form, mail_from, final_to, subject_line, text_body, html_body)
-        raw = mail.send(
-          to: final_to,
-          from: mail_from,
-          subject: subject_line,
-          text: text_body,
-          html: html_body
-        ).__await__
-
-        if `(#{raw} == null || #{raw} === undefined || #{raw} === Opal.nil)`
-          return error_result(form, mail_from, subject_line, 'SEND_EMAIL.send の戻りが null です。メールは送信されていません。')
-        end
-
-        message_id = extract_message_id(raw)
-        cf_raw = extract_cf_raw(raw)
-        success_result(form, mail_from, final_to, subject_line, message_id, cf_raw)
-      rescue Cloudflare::Email::Error => e
-        code = e.code.to_s
-        error_result(form, mail_from, subject_line, "#{code}: #{e.message}".strip)
       end
 
       def extract_message_id(result)

--- a/app/lib/debug_mail_controller.rb
+++ b/app/lib/debug_mail_controller.rb
@@ -4,7 +4,6 @@
 # Opal は `# await:` ブロック外のヘルパー内では `.__await__` が Promise を解決しない)。
 
 require 'json'
-require 'uri'
 
 module Homurabi
   module DebugMailController
@@ -77,28 +76,10 @@ module Homurabi
 
       private
 
-      # application/x-www-form-urlencoded 由来の `+` と、ツール連発などで混入しがちな
-      # 「閉じタグだけ %2F のまま」「:: が %3A%3A」のような **残留パーセントエンコード**を緩く直す。
-      # 完全なデコードは Rack が担当。ここでは最大 2 周だけ（decode 不能なら原文のまま）。
+      # `+` → space のみ（application/x-www-form-urlencoded）。
+      # `%2F` 等は Rack が `URI.decode_www_form_component`（Opal では decodeURIComponent）で解く。
       def sanitize_form(value)
-        s = value.to_s.tr('+', ' ')
-        decode_percent_runaway(s)
-      end
-
-      def decode_percent_runaway(s)
-        return s unless s.include?('%')
-        out = s
-        2.times do
-          break unless /%[0-9A-Fa-f]{2}/.match?(out)
-          begin
-            d = URI.decode_www_form_component(out)
-            break if d == out
-            out = d
-          rescue ArgumentError, URI::InvalidURIError
-            break
-          end
-        end
-        out
+        value.to_s.tr('+', ' ')
       end
 
       def vid_from_env(env)

--- a/app/lib/debug_mail_controller.rb
+++ b/app/lib/debug_mail_controller.rb
@@ -14,13 +14,13 @@ module Homurabi
         /homurabi Phase 17 test.{0,3}Version\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
 
       def parse_form_params(params, default_to: false)
-        to = params['to'].to_s.strip
+        to = sanitize_form(params['to']).strip
         to = DEFAULT_TO if default_to && to.empty?
         {
           to: to,
-          subject: sanitize_form(params['subject'].to_s.strip),
-          text: sanitize_form(params['text'].to_s),
-          html: sanitize_form(params['html'].to_s)
+          subject: sanitize_form(params['subject']).strip,
+          text: sanitize_form(params['text']),
+          html: sanitize_form(params['html'])
         }
       end
 
@@ -76,10 +76,9 @@ module Homurabi
 
       private
 
-      # `+` → space のみ（application/x-www-form-urlencoded）。
-      # `%2F` 等は Rack が `URI.decode_www_form_component`（Opal では decodeURIComponent）で解く。
+      # `Homurabi::DebugMailHelpers.www_decode` — `+` / `%xx`（閉じタグの `%2F` 等）を確実に直す。
       def sanitize_form(value)
-        value.to_s.tr('+', ' ')
+        Homurabi::DebugMailHelpers.www_decode(value)
       end
 
       def vid_from_env(env)

--- a/app/routes/bootstrap.rb
+++ b/app/routes/bootstrap.rb
@@ -66,3 +66,6 @@
 # fragments/route_062
 # fragments/route_063
 # fragments/route_064
+# fragments/route_065
+# fragments/route_066
+# fragments/route_067

--- a/app/routes/canonical_all.rb
+++ b/app/routes/canonical_all.rb
@@ -1921,44 +1921,42 @@
 
     if homurabi_mail_from.empty?
       @error = 'HOMURABI_MAIL_FROM が未設定です。ドメイン onboarding 後に wrangler [vars] で verified の送信元アドレスを設定してください。'
-      return erb :debug_mail
-    end
-
-    mail = send_email
-    unless mail&.available?
-      @error = 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。'
-      return erb :debug_mail
-    end
-
-    vid = env['HTTP_CF_RAY'].to_s.split('-').first
-    vid = Time.now.to_i.to_s if vid.nil? || vid.empty?
-    subject_line =
-      if @form_subject.empty?
-        "homurabi Phase 17 test — #{vid}"
+    else
+      mail = send_email
+      unless mail&.available?
+        @error = 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。'
       else
-        "#{@form_subject} — #{vid}"
-      end
+        vid = env['HTTP_CF_RAY'].to_s.split('-').first
+        vid = Time.now.to_i.to_s if vid.nil? || vid.empty?
+        subject_line =
+          if @form_subject.empty?
+            "homurabi Phase 17 test — #{vid}"
+          else
+            "#{@form_subject} — #{vid}"
+          end
 
-    body_text =
-      if @form_text.strip.empty?
-        'This is a test mail from homurabi'
-      else
-        @form_text
-      end
+        body_text =
+          if @form_text.strip.empty?
+            'This is a test mail from homurabi'
+          else
+            @form_text
+          end
 
-    begin
-      result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text).__await__
-      rid = result && (result[:message_id] || result['message_id'])
-      @success_json = JSON.pretty_generate({
-        'ok'           => true,
-        'message_id'   => rid,
-        'to'           => final_to,
-        'from'         => homurabi_mail_from,
-        'subject'      => subject_line
-      })
-    rescue Cloudflare::Email::Error => e
-      code = e.code.to_s
-      @error = "#{code}: #{e.message}".strip
+        begin
+          result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text).__await__
+          rid = result && (result[:message_id] || result['message_id'])
+          @success_json = JSON.pretty_generate({
+            'ok'           => true,
+            'message_id'   => rid,
+            'to'           => final_to,
+            'from'         => homurabi_mail_from,
+            'subject'      => subject_line
+          })
+        rescue Cloudflare::Email::Error => e
+          code = e.code.to_s
+          @error = "#{code}: #{e.message}".strip
+        end
+      end
     end
 
     erb :debug_mail

--- a/app/routes/canonical_all.rb
+++ b/app/routes/canonical_all.rb
@@ -1903,10 +1903,8 @@
 
     @title = 'Debug — mail'
     @mail_from = homurabi_mail_from
-    @form_to = (params['to'] || 'kazu.homma@gmail.com').to_s
-    @form_subject = params['subject'].to_s
-    @form_text = params['text'].to_s
-    @form_html = params['html'].to_s
+    @form = Homurabi::DebugMailController.parse_form_params(params, default_to: true)
+    @result = nil
     erb :debug_mail
   end
 
@@ -1918,90 +1916,8 @@
 
     @title = 'Debug — mail'
     @mail_from = homurabi_mail_from
-    @form_to = params['to'].to_s.strip
-    # urlencoded 本文で + がスペースにならず残るクライアントがあるため表示用に正規化
-    @form_subject = params['subject'].to_s.strip.tr('+', ' ')
-    @form_text = params['text'].to_s.tr('+', ' ')
-    @form_html = params['html'].to_s.tr('+', ' ')
-
-    final_to = @form_to.empty? ? 'kazu.homma@gmail.com' : @form_to
-
-    if homurabi_mail_from.empty?
-      @error = 'HOMURABI_MAIL_FROM が未設定です。ドメイン onboarding 後に wrangler [vars] で verified の送信元アドレスを設定してください。'
-    else
-      mail = send_email
-      available = !mail.nil? && mail.available?
-      unless available
-        @error = 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。'
-      else
-        vid = env['HTTP_CF_RAY'].to_s.split('-').first
-        vid = Time.now.to_i.to_s if vid.nil? || vid.empty?
-        # application/x-www-form-urlencoded の + / 省略ダッシュゆらぎを吸収
-        fs = @form_subject.to_s.strip.tr('+', ' ')
-        subject_line =
-          if fs.empty?
-            "homurabi Phase 17 test — #{vid}"
-          elsif fs =~ /homurabi Phase 17 test.{0,3}Version\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
-            fs
-          else
-            "#{fs} — #{vid}"
-          end
-
-        body_html = @form_html.strip.empty? ? nil : @form_html
-        body_text =
-          if @form_text.strip.empty?
-            body_html ? nil : 'This is a test mail from homurabi'
-          else
-            @form_text
-          end
-
-        begin
-          result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text,
-                               html: body_html).__await__
-          mid_s = ''
-          cf_raw = ''
-          if `(#{result} == null || #{result} === undefined || #{result} === Opal.nil)`
-            @error = 'SEND_EMAIL.send の戻りが null です。メールは送信されていません。'
-          else
-            mid_s = begin
-              v = nil
-              v ||= result['message_id'] if result.respond_to?(:[])
-              v ||= result[:message_id] if result.respond_to?(:[])
-              v ||= result['messageId'] if result.respond_to?(:[])
-              v ||= result[:messageId] if result.respond_to?(:[])
-              v.to_s
-            rescue StandardError
-              ''
-            end
-            cf_raw = begin
-              (result['cf_send_result_json'] || result[:cf_send_result_json]).to_s
-            rescue StandardError
-              ''
-            end
-          end
-          # message_id 空は「API が受付 ID を返していない」＝ダッシュボード 0 と整合しがちなので ok は偽。
-          accepted = !mid_s.strip.empty?
-          warn =
-            accepted ? nil : 'message_id が空です。cf_send_result_json を確認してください。送信はキューに載っていない可能性があります。'
-          # Opal Hash/JSON.generate can raise on nested types — build a minimal JSON string。
-          # null 応答時は JSON を出さず @error のみ。
-          unless @error
-            @success_json =
-              '{"ok":' + (accepted ? 'true' : 'false') +
-              ',"message_id":' + mid_s.inspect +
-              ',"cf_send_result_json":' + cf_raw.inspect +
-              ',"to":' + final_to.inspect +
-              ',"from":' + homurabi_mail_from.inspect +
-              ',"subject":' + subject_line.inspect +
-              (warn ? ',"warning":' + warn.inspect : '') + '}'
-          end
-        rescue Cloudflare::Email::Error => e
-          code = e.code.to_s
-          @error = "#{code}: #{e.message}".strip
-        end
-      end
-    end
-
+    @result = Homurabi::DebugMailController.send_test_mail(params, env, self)
+    @form = @result[:form]
     erb :debug_mail
   end
 

--- a/app/routes/canonical_all.rb
+++ b/app/routes/canonical_all.rb
@@ -721,20 +721,20 @@
     # mint_session_cookie is sync (HMAC-SHA256 via node:crypto).
     # Keeping the route body sync lets `redirect` work normally.
     token = mint_session_cookie(username)
-    response.set_cookie(SESSION_COOKIE_NAME, {
+    response.set_cookie(App::SESSION_COOKIE_NAME, {
       value: token,
       path: '/',
       httponly: true,
       secure: request.scheme == 'https',
       same_site: :lax,
-      max_age: SESSION_COOKIE_TTL
+      max_age: App::SESSION_COOKIE_TTL
     })
     # 303 See Other — explicitly tells the client to follow up with
     # GET, avoiding any ambiguous POST-replay semantics around 302.
     redirect return_to, 303
   end
   get '/logout' do
-    response.delete_cookie(SESSION_COOKIE_NAME, path: '/')
+    response.delete_cookie(App::SESSION_COOKIE_NAME, path: '/')
     redirect '/'
   end
   get '/chat' do
@@ -1918,8 +1918,9 @@
     @title = 'Debug — mail'
     @mail_from = homurabi_mail_from
     @form_to = params['to'].to_s.strip
-    @form_subject = params['subject'].to_s.strip
-    @form_text = params['text'].to_s
+    # urlencoded 本文で + がスペースにならず残るクライアントがあるため表示用に正規化
+    @form_subject = params['subject'].to_s.strip.tr('+', ' ')
+    @form_text = params['text'].to_s.tr('+', ' ')
 
     final_to = @form_to.empty? ? 'kazu.homma@gmail.com' : @form_to
 
@@ -1927,16 +1928,21 @@
       @error = 'HOMURABI_MAIL_FROM が未設定です。ドメイン onboarding 後に wrangler [vars] で verified の送信元アドレスを設定してください。'
     else
       mail = send_email
-      unless mail&.available?
+      available = !mail.nil? && mail.available?
+      unless available
         @error = 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。'
       else
         vid = env['HTTP_CF_RAY'].to_s.split('-').first
         vid = Time.now.to_i.to_s if vid.nil? || vid.empty?
+        # application/x-www-form-urlencoded の + / 省略ダッシュゆらぎを吸収
+        fs = @form_subject.to_s.strip.tr('+', ' ')
         subject_line =
-          if @form_subject.empty?
+          if fs.empty?
             "homurabi Phase 17 test — #{vid}"
+          elsif fs =~ /homurabi Phase 17 test.{0,3}Version\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+            fs
           else
-            "#{@form_subject} — #{vid}"
+            "#{fs} — #{vid}"
           end
 
         body_text =
@@ -1948,14 +1954,43 @@
 
         begin
           result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text).__await__
-          rid = result && (result[:message_id] || result['message_id'])
-          @success_json = JSON.pretty_generate({
-            'ok'           => true,
-            'message_id'   => rid,
-            'to'           => final_to,
-            'from'         => homurabi_mail_from,
-            'subject'      => subject_line
-          })
+          mid_s = ''
+          cf_raw = ''
+          if `(#{result} == null || #{result} === undefined || #{result} === Opal.nil)`
+            @error = 'SEND_EMAIL.send の戻りが null です。メールは送信されていません。'
+          else
+            mid_s = begin
+              v = nil
+              v ||= result['message_id'] if result.respond_to?(:[])
+              v ||= result[:message_id] if result.respond_to?(:[])
+              v ||= result['messageId'] if result.respond_to?(:[])
+              v ||= result[:messageId] if result.respond_to?(:[])
+              v.to_s
+            rescue StandardError
+              ''
+            end
+            cf_raw = begin
+              (result['cf_send_result_json'] || result[:cf_send_result_json]).to_s
+            rescue StandardError
+              ''
+            end
+          end
+          # message_id 空は「API が受付 ID を返していない」＝ダッシュボード 0 と整合しがちなので ok は偽。
+          accepted = !mid_s.strip.empty?
+          warn =
+            accepted ? nil : 'message_id が空です。cf_send_result_json を確認してください。送信はキューに載っていない可能性があります。'
+          # Opal Hash/JSON.generate can raise on nested types — build a minimal JSON string。
+          # null 応答時は JSON を出さず @error のみ。
+          unless @error
+            @success_json =
+              '{"ok":' + (accepted ? 'true' : 'false') +
+              ',"message_id":' + mid_s.inspect +
+              ',"cf_send_result_json":' + cf_raw.inspect +
+              ',"to":' + final_to.inspect +
+              ',"from":' + homurabi_mail_from.inspect +
+              ',"subject":' + subject_line.inspect +
+              (warn ? ',"warning":' + warn.inspect : '') + '}'
+          end
         rescue Cloudflare::Email::Error => e
           code = e.code.to_s
           @error = "#{code}: #{e.message}".strip

--- a/app/routes/canonical_all.rb
+++ b/app/routes/canonical_all.rb
@@ -1916,7 +1916,25 @@
 
     @title = 'Debug — mail'
     @mail_from = homurabi_mail_from
-    @result = Homurabi::DebugMailController.send_test_mail(params, env, self)
+
+    ctx = Homurabi::DebugMailController.prepare_send(params, env, self)
+    if ctx[:error_result]
+      @result = ctx[:error_result]
+    else
+      begin
+        raw = ctx[:mail].send(
+          to: ctx[:final_to],
+          from: ctx[:mail_from],
+          subject: ctx[:subject_line],
+          text: ctx[:text_body],
+          html: ctx[:html_body]
+        ).__await__
+        @result = Homurabi::DebugMailController.after_send_success(raw, ctx)
+      rescue Cloudflare::Email::Error => e
+        @result = Homurabi::DebugMailController.after_send_failure(e, ctx)
+      end
+    end
+
     @form = @result[:form]
     erb :debug_mail
   end

--- a/app/routes/canonical_all.rb
+++ b/app/routes/canonical_all.rb
@@ -1906,6 +1906,7 @@
     @form_to = (params['to'] || 'kazu.homma@gmail.com').to_s
     @form_subject = params['subject'].to_s
     @form_text = params['text'].to_s
+    @form_html = params['html'].to_s
     erb :debug_mail
   end
 
@@ -1921,6 +1922,7 @@
     # urlencoded 本文で + がスペースにならず残るクライアントがあるため表示用に正規化
     @form_subject = params['subject'].to_s.strip.tr('+', ' ')
     @form_text = params['text'].to_s.tr('+', ' ')
+    @form_html = params['html'].to_s.tr('+', ' ')
 
     final_to = @form_to.empty? ? 'kazu.homma@gmail.com' : @form_to
 
@@ -1945,15 +1947,17 @@
             "#{fs} — #{vid}"
           end
 
+        body_html = @form_html.strip.empty? ? nil : @form_html
         body_text =
           if @form_text.strip.empty?
-            'This is a test mail from homurabi'
+            body_html ? nil : 'This is a test mail from homurabi'
           else
             @form_text
           end
 
         begin
-          result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text).__await__
+          result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text,
+                               html: body_html).__await__
           mid_s = ''
           cf_raw = ''
           if `(#{result} == null || #{result} === undefined || #{result} === Opal.nil)`

--- a/app/routes/canonical_all.rb
+++ b/app/routes/canonical_all.rb
@@ -1898,7 +1898,9 @@
   end
   # Phase 17 — Cloudflare Email Service (SEND_EMAIL) manual test
   get '/debug/mail' do
-    debug_mail_require_kazuph!
+    gate = debug_mail_gate_response
+    next gate if gate
+
     @title = 'Debug — mail'
     @mail_from = homurabi_mail_from
     @form_to = (params['to'] || 'kazu.homma@gmail.com').to_s
@@ -1908,7 +1910,9 @@
   end
 
   post '/debug/mail' do
-    debug_mail_require_kazuph!
+    gate = debug_mail_gate_response
+    next gate if gate
+
     content_type 'text/html; charset=utf-8'
 
     @title = 'Debug — mail'

--- a/app/routes/canonical_all.rb
+++ b/app/routes/canonical_all.rb
@@ -1896,3 +1896,91 @@
     @docs_inner = erb :docs_architecture
     erb :layout_docs
   end
+  # Phase 17 — Cloudflare Email Service (SEND_EMAIL) manual test
+  get '/debug/mail' do
+    debug_mail_require_kazuph!
+    @title = 'Debug — mail'
+    @mail_from = homurabi_mail_from
+    @form_to = (params['to'] || 'kazu.homma@gmail.com').to_s
+    @form_subject = params['subject'].to_s
+    @form_text = params['text'].to_s
+    erb :debug_mail
+  end
+
+  post '/debug/mail' do
+    debug_mail_require_kazuph!
+    content_type 'text/html; charset=utf-8'
+
+    @title = 'Debug — mail'
+    @mail_from = homurabi_mail_from
+    @form_to = params['to'].to_s.strip
+    @form_subject = params['subject'].to_s.strip
+    @form_text = params['text'].to_s
+
+    final_to = @form_to.empty? ? 'kazu.homma@gmail.com' : @form_to
+
+    if homurabi_mail_from.empty?
+      @error = 'HOMURABI_MAIL_FROM が未設定です。ドメイン onboarding 後に wrangler [vars] で verified の送信元アドレスを設定してください。'
+      return erb :debug_mail
+    end
+
+    mail = send_email
+    unless mail&.available?
+      @error = 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。'
+      return erb :debug_mail
+    end
+
+    vid = env['HTTP_CF_RAY'].to_s.split('-').first
+    vid = Time.now.to_i.to_s if vid.nil? || vid.empty?
+    subject_line =
+      if @form_subject.empty?
+        "homurabi Phase 17 test — #{vid}"
+      else
+        "#{@form_subject} — #{vid}"
+      end
+
+    body_text =
+      if @form_text.strip.empty?
+        'This is a test mail from homurabi'
+      else
+        @form_text
+      end
+
+    begin
+      result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text).__await__
+      rid = result && (result[:message_id] || result['message_id'])
+      @success_json = JSON.pretty_generate({
+        'ok'           => true,
+        'message_id'   => rid,
+        'to'           => final_to,
+        'from'         => homurabi_mail_from,
+        'subject'      => subject_line
+      })
+    rescue Cloudflare::Email::Error => e
+      code = e.code.to_s
+      @error = "#{code}: #{e.message}".strip
+    end
+
+    erb :debug_mail
+  end
+
+  get '/docs/email' do
+    @title = 'Cloudflare Email Service — homurabi Docs'
+    @docs_page = 'email'
+    @docs_section = :reference
+    @docs_breadcrumb = [
+      ['Docs', '/docs'],
+      ['API Reference', '/docs/runtime'],
+      ['Email Service', nil]
+    ]
+    @docs_toc = [
+      %w[overview 概要],
+      %w[setup domain onboarding],
+      %w[wrapper Cloudflare::Email],
+      %w[matrix できること / できないこと],
+      %w[debug /debug/mail],
+      %w[links 公式リンク]
+    ]
+    @docs_inner = erb :docs_email
+    erb :layout_docs
+  end

--- a/app/routes/demo.rb
+++ b/app/routes/demo.rb
@@ -1,6 +1,6 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
-# Domain: demo — fragment indices 1, 2, 3, 5, 6, 7, 8, 9, 13, 14, 15, 16, 17, 18, 19, 20, 21, 26, 39, 40, 41, 43, 44, 46, 47, 49, 51, 52, 53, 54, 55, 56, 58, 59, 60, 61, 62, 63, 64 (documentation only; routes load via app/app.rb).
+# Domain: demo — fragment indices 1, 2, 3, 5, 6, 7, 8, 9, 13, 14, 15, 16, 17, 18, 19, 20, 21, 26, 39, 40, 41, 43, 44, 46, 47, 49, 51, 52, 53, 54, 55, 56, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67 (documentation only; routes load via app/app.rb).
 # fragments/route_001
 # fragments/route_002
 # fragments/route_003
@@ -40,3 +40,6 @@
 # fragments/route_062
 # fragments/route_063
 # fragments/route_064
+# fragments/route_065
+# fragments/route_066
+# fragments/route_067

--- a/app/routes/fragments/route_001.rb
+++ b/app/routes/fragments/route_001.rb
@@ -1,9 +1,9 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 1 — demo /
-  get '/' do
-    @title = 'Hello from Sinatra'
-    @users = db ? db.execute('SELECT id, name FROM users ORDER BY id') : []
-    @content = erb :index
-    erb :layout
-  end
+get '/' do
+  @title = 'Hello from Sinatra'
+  @users = db ? db.execute('SELECT id, name FROM users ORDER BY id') : []
+  @content = erb :index
+  erb :layout
+end

--- a/app/routes/fragments/route_002.rb
+++ b/app/routes/fragments/route_002.rb
@@ -1,9 +1,9 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 2 — demo /hello/:name
-  get '/hello/:name' do
-    @title = "Hello #{params['name']}"
-    @name  = params['name']
-    @content = erb :hello
-    erb :layout
-  end
+get '/hello/:name' do
+  @title = "Hello #{params['name']}"
+  @name  = params['name']
+  @content = erb :hello
+  erb :layout
+end

--- a/app/routes/fragments/route_003.rb
+++ b/app/routes/fragments/route_003.rb
@@ -1,8 +1,8 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 3 — demo /about
-  get '/about' do
-    @title = 'About homurabi'
-    @content = erb :about
-    erb :layout
-  end
+get '/about' do
+  @title = 'About homurabi'
+  @content = erb :about
+  erb :layout
+end

--- a/app/routes/fragments/route_004.rb
+++ b/app/routes/fragments/route_004.rb
@@ -1,9 +1,9 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 4 — api /api/echo
-  post '/api/echo' do
-    content_type 'application/json'
-    request.body.rewind
-    body = request.body.read
-    "{\"echo\": \"#{body}\"}"
-  end
+post '/api/echo' do
+  content_type 'application/json'
+  request.body.rewind
+  body = request.body.read
+  "{\"echo\": \"#{body}\"}"
+end

--- a/app/routes/fragments/route_005.rb
+++ b/app/routes/fragments/route_005.rb
@@ -1,7 +1,7 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 5 — demo /d1/users
-  get '/d1/users' do
-    content_type 'application/json'
-    db.execute('SELECT id, name FROM users ORDER BY id').to_json
-  end
+get '/d1/users' do
+  content_type 'application/json'
+  db.execute('SELECT id, name FROM users ORDER BY id').to_json
+end

--- a/app/routes/fragments/route_006.rb
+++ b/app/routes/fragments/route_006.rb
@@ -1,14 +1,14 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 6 — demo /d1/users/:id
-  get '/d1/users/:id' do
-    content_type 'application/json'
-    id = params['id'].to_i
-    row = db.get_first_row('SELECT id, name FROM users WHERE id = ?', [id])
-    if row.nil?
-      status 404
-      { 'error' => 'not found', 'id' => id }.to_json
-    else
-      row.to_json
-    end
+get '/d1/users/:id' do
+  content_type 'application/json'
+  id = params['id'].to_i
+  row = db.get_first_row('SELECT id, name FROM users WHERE id = ?', [id])
+  if row.nil?
+    status 404
+    { 'error' => 'not found', 'id' => id }.to_json
+  else
+    row.to_json
   end
+end

--- a/app/routes/fragments/route_007.rb
+++ b/app/routes/fragments/route_007.rb
@@ -1,21 +1,21 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 7 — demo /d1/users
-  post '/d1/users' do
-    content_type 'application/json'
-    begin
-      payload = JSON.parse(request.body.read)
-    rescue JSON::ParserError, StandardError => e
-      status 400
-      return { 'error' => 'invalid JSON body', 'detail' => e.message }.to_json
-    end
-    name = payload['name'].to_s
-    if name.empty?
-      status 400
-      { 'error' => 'name required' }.to_json
-    else
-      row = db.get_first_row('INSERT INTO users (name) VALUES (?) RETURNING id, name', [name])
-      status 201
-      row.to_json
-    end
+post '/d1/users' do
+  content_type 'application/json'
+  begin
+    payload = JSON.parse(request.body.read)
+  rescue JSON::ParserError, StandardError => e
+    status 400
+    return { 'error' => 'invalid JSON body', 'detail' => e.message }.to_json
   end
+  name = payload['name'].to_s
+  if name.empty?
+    status 400
+    { 'error' => 'name required' }.to_json
+  else
+    row = db.get_first_row('INSERT INTO users (name) VALUES (?) RETURNING id, name', [name])
+    status 201
+    row.to_json
+  end
+end

--- a/app/routes/fragments/route_008.rb
+++ b/app/routes/fragments/route_008.rb
@@ -1,9 +1,9 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 8 — demo /demo/sequel
-  get '/demo/sequel' do
-    content_type 'application/json'
-    seq_db = Sequel.connect(adapter: :d1, d1: db)
-    rows = seq_db[:users].order(:id).limit(10).all
-    { 'rows' => rows, 'adapter' => 'sequel-d1', 'dialect' => 'sqlite' }.to_json
-  end
+get '/demo/sequel' do
+  content_type 'application/json'
+  seq_db = Sequel.connect(adapter: :d1, d1: db)
+  rows = seq_db[:users].order(:id).limit(10).all
+  { 'rows' => rows, 'adapter' => 'sequel-d1', 'dialect' => 'sqlite' }.to_json
+end

--- a/app/routes/fragments/route_009.rb
+++ b/app/routes/fragments/route_009.rb
@@ -1,9 +1,9 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 9 — demo /demo/sequel/sql
-  get '/demo/sequel/sql' do
-    content_type 'application/json'
-    seq_db = Sequel.connect(adapter: :d1, d1: db)
-    ds = seq_db[:users].where(active: true).order(:name).limit(10)
-    { 'sql' => ds.sql.to_s, 'adapter' => 'sequel-d1' }.to_json
-  end
+get '/demo/sequel/sql' do
+  content_type 'application/json'
+  seq_db = Sequel.connect(adapter: :d1, d1: db)
+  ds = seq_db[:users].where(active: true).order(:name).limit(10)
+  { 'sql' => ds.sql.to_s, 'adapter' => 'sequel-d1' }.to_json
+end

--- a/app/routes/fragments/route_010.rb
+++ b/app/routes/fragments/route_010.rb
@@ -1,9 +1,9 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 10 — posts /posts
-  get '/posts' do
-    content_type 'application/json'
-    seq_db = Sequel.connect(adapter: :d1, d1: db)
-    rows = seq_db[:posts].order(Sequel.desc(:id)).limit(20).all
-    { 'count' => rows.size, 'posts' => rows }.to_json
-  end
+get '/posts' do
+  content_type 'application/json'
+  seq_db = Sequel.connect(adapter: :d1, d1: db)
+  rows = seq_db[:posts].order(Sequel.desc(:id)).limit(20).all
+  { 'count' => rows.size, 'posts' => rows }.to_json
+end

--- a/app/routes/fragments/route_011.rb
+++ b/app/routes/fragments/route_011.rb
@@ -1,28 +1,28 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 11 — posts /posts
-  post '/posts' do
-    content_type 'application/json'
-    begin
-      payload = JSON.parse(request.body.read)
-    rescue JSON::ParserError, StandardError => e
-      status 400
-      next({ 'error' => "invalid JSON: #{e.message}" }.to_json)
-    end
-    title = payload['title'].to_s.strip
-    body_text = payload['body'].to_s.strip
-    if title.empty?
-      status 400
-      next({ 'error' => 'title is required' }.to_json)
-    end
-    # Use Cloudflare::D1Database directly for the insert + readback.
-    # D1's execute() accepts `?` placeholders and binds as an Array,
-    # matching sqlite3-ruby's idiom (same shape `/d1/users POST`
-    # route already relies on).
-    row = db.get_first_row(
-      'INSERT INTO posts (title, body) VALUES (?, ?) RETURNING id, title, body, created_at',
-      [title, body_text]
-    )
-    status 201
-    { 'ok' => true, 'post' => row }.to_json
+post '/posts' do
+  content_type 'application/json'
+  begin
+    payload = JSON.parse(request.body.read)
+  rescue JSON::ParserError, StandardError => e
+    status 400
+    next({ 'error' => "invalid JSON: #{e.message}" }.to_json)
   end
+  title = payload['title'].to_s.strip
+  body_text = payload['body'].to_s.strip
+  if title.empty?
+    status 400
+    next({ 'error' => 'title is required' }.to_json)
+  end
+  # Use Cloudflare::D1Database directly for the insert + readback.
+  # D1's execute() accepts `?` placeholders and binds as an Array,
+  # matching sqlite3-ruby's idiom (same shape `/d1/users POST`
+  # route already relies on).
+  row = db.get_first_row(
+    'INSERT INTO posts (title, body) VALUES (?, ?) RETURNING id, title, body, created_at',
+    [title, body_text]
+  )
+  status 201
+  { 'ok' => true, 'post' => row }.to_json
+end

--- a/app/routes/fragments/route_012.rb
+++ b/app/routes/fragments/route_012.rb
@@ -1,44 +1,44 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 12 — test /test/sequel
-  get '/test/sequel' do
-    content_type 'application/json'
-    cases = []
-    run = lambda { |label, &blk|
-      result = begin
-        v = blk.call
-        v == false ? { 'pass' => false, 'note' => 'returned false' } : { 'pass' => true }
-      rescue ::Exception => e
-        { 'pass' => false, 'note' => "#{e.class}: #{e.message[0, 200]}" }
-      end
-      cases << result.merge('case' => label)
-    }
+get '/test/sequel' do
+  content_type 'application/json'
+  cases = []
+  run = lambda { |label, &blk|
+    result = begin
+      v = blk.call
+      v == false ? { 'pass' => false, 'note' => 'returned false' } : { 'pass' => true }
+    rescue ::Exception => e
+      { 'pass' => false, 'note' => "#{e.class}: #{e.message[0, 200]}" }
+    end
+    cases << result.merge('case' => label)
+  }
 
-    seq_db = Sequel.connect(adapter: :d1, d1: db)
+  seq_db = Sequel.connect(adapter: :d1, d1: db)
 
-    run.call('adapter_scheme is :d1') { seq_db.adapter_scheme == :d1 }
-    run.call('database_type is :sqlite') { seq_db.database_type == :sqlite }
-    run.call('SingleConnectionPool in use') { seq_db.pool.class.name == 'Sequel::SingleConnectionPool' }
-    run.call('DB[:users].sql emits SELECT * FROM users') {
-      seq_db[:users].sql.to_s == 'SELECT * FROM `users`'
-    }
-    run.call('DB[:users].where(id: 1).sql emits id = 1') {
-      seq_db[:users].where(id: 1).sql.to_s == 'SELECT * FROM `users` WHERE (`id` = 1)'
-    }
-    run.call('DB[:users].order(:id).limit(5) emits ORDER BY + LIMIT') {
-      sql = seq_db[:users].order(:id).limit(5).sql.to_s
-      sql.include?('ORDER BY `id`') && sql.include?('LIMIT 5')
-    }
-    run.call('DB[:users].all hits D1 and returns rows') {
-      rows = seq_db[:users].all
-      rows.is_a?(Array) && rows.all? { |r| r.is_a?(Hash) && r['id'] && r['name'] }
-    }
-    run.call('DB[:users].where(id: 1).first.__await__ returns single row') {
-      row = seq_db[:users].where(id: 1).first.__await__
-      row.is_a?(Hash) && row['id'].to_i == 1
-    }
+  run.call('adapter_scheme is :d1') { seq_db.adapter_scheme == :d1 }
+  run.call('database_type is :sqlite') { seq_db.database_type == :sqlite }
+  run.call('SingleConnectionPool in use') { seq_db.pool.class.name == 'Sequel::SingleConnectionPool' }
+  run.call('DB[:users].sql emits SELECT * FROM users') {
+    seq_db[:users].sql.to_s == 'SELECT * FROM `users`'
+  }
+  run.call('DB[:users].where(id: 1).sql emits id = 1') {
+    seq_db[:users].where(id: 1).sql.to_s == 'SELECT * FROM `users` WHERE (`id` = 1)'
+  }
+  run.call('DB[:users].order(:id).limit(5) emits ORDER BY + LIMIT') {
+    sql = seq_db[:users].order(:id).limit(5).sql.to_s
+    sql.include?('ORDER BY `id`') && sql.include?('LIMIT 5')
+  }
+  run.call('DB[:users].all hits D1 and returns rows') {
+    rows = seq_db[:users].all
+    rows.is_a?(Array) && rows.all? { |r| r.is_a?(Hash) && r['id'] && r['name'] }
+  }
+  run.call('DB[:users].where(id: 1).first.__await__ returns single row') {
+    row = seq_db[:users].where(id: 1).first.__await__
+    row.is_a?(Hash) && row['id'].to_i == 1
+  }
 
-    pass_count = cases.count { |c| c['pass'] }
-    { 'phase' => 12, 'total' => cases.size, 'passed' => pass_count,
-      'failed' => cases.size - pass_count, 'cases' => cases }.to_json
-  end
+  pass_count = cases.count { |c| c['pass'] }
+  { 'phase' => 12, 'total' => cases.size, 'passed' => pass_count,
+    'failed' => cases.size - pass_count, 'cases' => cases }.to_json
+end

--- a/app/routes/fragments/route_013.rb
+++ b/app/routes/fragments/route_013.rb
@@ -1,14 +1,14 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 13 — demo /kv/:key
-  get '/kv/:key' do
-    content_type 'application/json'
-    key = params['key']
-    value = kv.get(key).__await__
-    if value.nil?
-      status 404
-      { 'error' => 'not found', 'key' => key }.to_json
-    else
-      { 'key' => key, 'value' => value }.to_json
-    end
+get '/kv/:key' do
+  content_type 'application/json'
+  key = params['key']
+  value = kv.get(key).__await__
+  if value.nil?
+    status 404
+    { 'error' => 'not found', 'key' => key }.to_json
+  else
+    { 'key' => key, 'value' => value }.to_json
   end
+end

--- a/app/routes/fragments/route_014.rb
+++ b/app/routes/fragments/route_014.rb
@@ -1,11 +1,11 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 14 — demo /kv/:key
-  put '/kv/:key' do
-    content_type 'application/json'
-    key  = params['key']
-    body = request.body.read
-    kv.put(key, body).__await__
-    status 201
-    { 'key' => key, 'value' => body, 'stored' => true }.to_json
-  end
+put '/kv/:key' do
+  content_type 'application/json'
+  key  = params['key']
+  body = request.body.read
+  kv.put(key, body).__await__
+  status 201
+  { 'key' => key, 'value' => body, 'stored' => true }.to_json
+end

--- a/app/routes/fragments/route_015.rb
+++ b/app/routes/fragments/route_015.rb
@@ -1,9 +1,9 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 15 — demo /kv/:key
-  delete '/kv/:key' do
-    content_type 'application/json'
-    key = params['key']
-    kv.delete(key).__await__
-    { 'key' => key, 'deleted' => true }.to_json
-  end
+delete '/kv/:key' do
+  content_type 'application/json'
+  key = params['key']
+  kv.delete(key).__await__
+  { 'key' => key, 'deleted' => true }.to_json
+end

--- a/app/routes/fragments/route_016.rb
+++ b/app/routes/fragments/route_016.rb
@@ -1,13 +1,13 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 16 — demo /images/:key
-  get '/images/:key' do
-    key    = params['key']
-    obj    = bucket.get_binary(key)
-    if obj.nil?
-      status 404
-      'not found'
-    else
-      obj  # BinaryBody — build_js_response detects and streams directly
-    end
+get '/images/:key' do
+  key    = params['key']
+  obj    = bucket.get_binary(key)
+  if obj.nil?
+    status 404
+    'not found'
+  else
+    obj  # BinaryBody — build_js_response detects and streams directly
   end
+end

--- a/app/routes/fragments/route_017.rb
+++ b/app/routes/fragments/route_017.rb
@@ -1,19 +1,19 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 17 — demo /r2/:key
-  get '/r2/:key' do
-    content_type 'application/json'
-    key    = params['key']
-    obj    = bucket.get(key).__await__
-    if obj.nil?
-      status 404
-      { 'error' => 'not found', 'key' => key }.to_json
-    else
-      {
-        'key'  => obj['key'],
-        'body' => obj['body'],
-        'etag' => obj['etag'],
-        'size' => obj['size']
-      }.to_json
-    end
+get '/r2/:key' do
+  content_type 'application/json'
+  key    = params['key']
+  obj    = bucket.get(key).__await__
+  if obj.nil?
+    status 404
+    { 'error' => 'not found', 'key' => key }.to_json
+  else
+    {
+      'key'  => obj['key'],
+      'body' => obj['body'],
+      'etag' => obj['etag'],
+      'size' => obj['size']
+    }.to_json
   end
+end

--- a/app/routes/fragments/route_018.rb
+++ b/app/routes/fragments/route_018.rb
@@ -1,12 +1,12 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 18 — demo /r2/:key
-  put '/r2/:key' do
-    content_type 'application/json'
-    key             = params['key']
-    body            = request.body.read rescue ''
-    content_type_in = request.env['CONTENT_TYPE'] || 'application/octet-stream'
-    bucket.put(key, body, content_type_in).__await__
-    status 201
-    { 'key' => key, 'size' => body.bytesize, 'stored' => true }.to_json
-  end
+put '/r2/:key' do
+  content_type 'application/json'
+  key             = params['key']
+  body            = request.body.read rescue ''
+  content_type_in = request.env['CONTENT_TYPE'] || 'application/octet-stream'
+  bucket.put(key, body, content_type_in).__await__
+  status 201
+  { 'key' => key, 'size' => body.bytesize, 'stored' => true }.to_json
+end

--- a/app/routes/fragments/route_019.rb
+++ b/app/routes/fragments/route_019.rb
@@ -1,9 +1,9 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 19 — demo /r2/:key
-  delete '/r2/:key' do
-    content_type 'application/json'
-    key    = params['key']
-    bucket.delete(key).__await__
-    { 'key' => key, 'deleted' => true }.to_json
-  end
+delete '/r2/:key' do
+  content_type 'application/json'
+  key    = params['key']
+  bucket.delete(key).__await__
+  { 'key' => key, 'deleted' => true }.to_json
+end

--- a/app/routes/fragments/route_020.rb
+++ b/app/routes/fragments/route_020.rb
@@ -1,14 +1,14 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 20 — demo /demo/http
-  get '/demo/http' do
-    content_type 'application/json'
-    res = Net::HTTP.get_response(URI('https://api.ipify.org/?format=json'))
-    {
-      'demo'    => 'Net::HTTP through Cloudflare fetch',
-      'status'  => res.code,
-      'message' => res.message,
-      'content_type' => res['content-type'],
-      'body'    => JSON.parse(res.body)
-    }.to_json
-  end
+get '/demo/http' do
+  content_type 'application/json'
+  res = Net::HTTP.get_response(URI('https://api.ipify.org/?format=json'))
+  {
+    'demo'    => 'Net::HTTP through Cloudflare fetch',
+    'status'  => res.code,
+    'message' => res.message,
+    'content_type' => res['content-type'],
+    'body'    => JSON.parse(res.body)
+  }.to_json
+end

--- a/app/routes/fragments/route_021.rb
+++ b/app/routes/fragments/route_021.rb
@@ -1,14 +1,14 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 21 — demo /demo/http/raw
-  get '/demo/http/raw' do
-    content_type 'application/json'
-    res = Cloudflare::HTTP.fetch('https://api.ipify.org/?format=json')
-    {
-      'demo'    => 'Cloudflare::HTTP.fetch (raw)',
-      'status'  => res.status,
-      'ok'      => res.ok?,
-      'headers' => { 'content-type' => res['content-type'] },
-      'json'    => res.json
-    }.to_json
-  end
+get '/demo/http/raw' do
+  content_type 'application/json'
+  res = Cloudflare::HTTP.fetch('https://api.ipify.org/?format=json')
+  {
+    'demo'    => 'Cloudflare::HTTP.fetch (raw)',
+    'status'  => res.status,
+    'ok'      => res.ok?,
+    'headers' => { 'content-type' => res['content-type'] },
+    'json'    => res.json
+  }.to_json
+end

--- a/app/routes/fragments/route_022.rb
+++ b/app/routes/fragments/route_022.rb
@@ -1,56 +1,56 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 22 — api /api/login
-  post '/api/login' do
-    content_type 'application/json'
-    alg = params['alg'] || 'HS256'
-    begin
-      body = JSON.parse(request.body.read)
-    rescue JSON::ParserError, StandardError
-      body = {}
-    end
-    username = body['username'].to_s
-    username = 'demo' if username.empty?
+post '/api/login' do
+  content_type 'application/json'
+  alg = params['alg'] || 'HS256'
+  begin
+    body = JSON.parse(request.body.read)
+  rescue JSON::ParserError, StandardError
+    body = {}
+  end
+  username = body['username'].to_s
+  username = 'demo' if username.empty?
 
-    begin
-      sign_key, _ = jwt_keys_for(alg)
-    rescue ArgumentError => e
-      status 400
-      return { 'error' => e.message }.to_json
-    end
+  begin
+    sign_key, _ = jwt_keys_for(alg)
+  rescue ArgumentError => e
+    status 400
+    return { 'error' => e.message }.to_json
+  end
 
-    payload = {
+  payload = {
+    'sub'  => username,
+    'role' => body['role'] || 'user',
+    'iat'  => Time.now.to_i,
+    'exp'  => Time.now.to_i + JWT_ACCESS_TTL
+  }
+  access_token = JWT.encode(payload, sign_key, alg)
+
+  # Refresh token: opaque random string. Only minted when KV is bound
+  # (otherwise the token would never round-trip through /api/login/refresh
+  # and we'd be lying about rotation support). Store the role in the KV
+  # entry so refresh preserves the original role instead of demoting
+  # non-default roles to 'user' on re-issue.
+  refresh = nil
+  if kv
+    refresh = SecureRandom.urlsafe_base64(48)
+    entry = {
       'sub'  => username,
       'role' => body['role'] || 'user',
-      'iat'  => Time.now.to_i,
-      'exp'  => Time.now.to_i + JWT_ACCESS_TTL
+      'alg'  => alg,
+      'exp'  => Time.now.to_i + JWT_REFRESH_TTL
     }
-    access_token = JWT.encode(payload, sign_key, alg)
-
-    # Refresh token: opaque random string. Only minted when KV is bound
-    # (otherwise the token would never round-trip through /api/login/refresh
-    # and we'd be lying about rotation support). Store the role in the KV
-    # entry so refresh preserves the original role instead of demoting
-    # non-default roles to 'user' on re-issue.
-    refresh = nil
-    if kv
-      refresh = SecureRandom.urlsafe_base64(48)
-      entry = {
-        'sub'  => username,
-        'role' => body['role'] || 'user',
-        'alg'  => alg,
-        'exp'  => Time.now.to_i + JWT_REFRESH_TTL
-      }
-      kv.put("refresh:#{refresh}", entry.to_json).__await__
-    end
-
-    status 201
-    resp = {
-      'access_token' => access_token,
-      'token_type'   => 'Bearer',
-      'expires_in'   => JWT_ACCESS_TTL,
-      'alg'          => alg
-    }
-    resp['refresh_token'] = refresh if refresh
-    resp.to_json
+    kv.put("refresh:#{refresh}", entry.to_json).__await__
   end
+
+  status 201
+  resp = {
+    'access_token' => access_token,
+    'token_type'   => 'Bearer',
+    'expires_in'   => JWT_ACCESS_TTL,
+    'alg'          => alg
+  }
+  resp['refresh_token'] = refresh if refresh
+  resp.to_json
+end

--- a/app/routes/fragments/route_023.rb
+++ b/app/routes/fragments/route_023.rb
@@ -1,51 +1,51 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 23 — api /api/me
-  get '/api/me' do
-    content_type 'application/json'
-    auth_header = request.env['HTTP_AUTHORIZATION'].to_s
-    parts = auth_header.split(' ', 2)
-    if parts.length != 2 || parts[0].downcase != 'bearer'
-      status 401
-      next { 'error' => 'missing Authorization: Bearer header' }.to_json
-    end
-
-    token = parts[1].strip
-    if token.empty?
-      status 401
-      next { 'error' => 'missing Authorization: Bearer header' }.to_json
-    end
-
-    alg = alg_from_token(token)
-    if alg.nil? || alg == 'none'
-      status 401
-      next { 'error' => 'unknown or unsafe algorithm' }.to_json
-    end
-
-    begin
-      _, verify_key = jwt_keys_for(alg)
-    rescue ArgumentError => e
-      status 401
-      next { 'error' => e.message }.to_json
-    end
-
-    begin
-      payload, header = JWT.decode(token, verify_key, true, algorithm: alg)
-    rescue JWT::ExpiredSignature
-      status 401
-      next { 'error' => 'token expired' }.to_json
-    rescue JWT::VerificationError
-      status 401
-      next { 'error' => 'signature verification failed' }.to_json
-    rescue JWT::DecodeError => e
-      status 401
-      next({ 'error' => "invalid token: #{e.message}" }.to_json)
-    end
-
-    {
-      'current_user' => payload['sub'],
-      'role'         => payload['role'],
-      'alg'          => header['alg'],
-      'claims'       => payload
-    }.to_json
+get '/api/me' do
+  content_type 'application/json'
+  auth_header = request.env['HTTP_AUTHORIZATION'].to_s
+  parts = auth_header.split(' ', 2)
+  if parts.length != 2 || parts[0].downcase != 'bearer'
+    status 401
+    next { 'error' => 'missing Authorization: Bearer header' }.to_json
   end
+
+  token = parts[1].strip
+  if token.empty?
+    status 401
+    next { 'error' => 'missing Authorization: Bearer header' }.to_json
+  end
+
+  alg = alg_from_token(token)
+  if alg.nil? || alg == 'none'
+    status 401
+    next { 'error' => 'unknown or unsafe algorithm' }.to_json
+  end
+
+  begin
+    _, verify_key = jwt_keys_for(alg)
+  rescue ArgumentError => e
+    status 401
+    next { 'error' => e.message }.to_json
+  end
+
+  begin
+    payload, header = JWT.decode(token, verify_key, true, algorithm: alg)
+  rescue JWT::ExpiredSignature
+    status 401
+    next { 'error' => 'token expired' }.to_json
+  rescue JWT::VerificationError
+    status 401
+    next { 'error' => 'signature verification failed' }.to_json
+  rescue JWT::DecodeError => e
+    status 401
+    next({ 'error' => "invalid token: #{e.message}" }.to_json)
+  end
+
+  {
+    'current_user' => payload['sub'],
+    'role'         => payload['role'],
+    'alg'          => header['alg'],
+    'claims'       => payload
+  }.to_json
+end

--- a/app/routes/fragments/route_024.rb
+++ b/app/routes/fragments/route_024.rb
@@ -1,58 +1,58 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 24 — api /api/login/refresh
-  post '/api/login/refresh' do
-    content_type 'application/json'
-    if kv.nil?
-      status 500
-      next { 'error' => 'KV not bound' }.to_json
-    end
-
-    begin
-      body = JSON.parse(request.body.read)
-    rescue JSON::ParserError, StandardError
-      body = {}
-    end
-    refresh = body['refresh_token'].to_s
-    if refresh.empty?
-      status 400
-      next { 'error' => 'refresh_token required' }.to_json
-    end
-
-    raw = kv.get("refresh:#{refresh}").__await__
-    if raw.nil?
-      status 401
-      next { 'error' => 'unknown refresh_token' }.to_json
-    end
-
-    begin
-      entry = JSON.parse(raw)
-    rescue JSON::ParserError
-      status 500
-      next { 'error' => 'corrupt refresh entry' }.to_json
-    end
-
-    if entry['exp'].to_i < Time.now.to_i
-      kv.delete("refresh:#{refresh}").__await__
-      status 401
-      next { 'error' => 'refresh_token expired' }.to_json
-    end
-
-    alg = entry['alg'] || 'HS256'
-    sub = entry['sub']
-    sign_key, _ = jwt_keys_for(alg)
-    payload = {
-      'sub'  => sub,
-      'role' => entry['role'] || 'user',
-      'iat'  => Time.now.to_i,
-      'exp'  => Time.now.to_i + JWT_ACCESS_TTL
-    }
-    access_token = JWT.encode(payload, sign_key, alg)
-
-    {
-      'access_token' => access_token,
-      'token_type'   => 'Bearer',
-      'expires_in'   => JWT_ACCESS_TTL,
-      'alg'          => alg
-    }.to_json
+post '/api/login/refresh' do
+  content_type 'application/json'
+  if kv.nil?
+    status 500
+    next { 'error' => 'KV not bound' }.to_json
   end
+
+  begin
+    body = JSON.parse(request.body.read)
+  rescue JSON::ParserError, StandardError
+    body = {}
+  end
+  refresh = body['refresh_token'].to_s
+  if refresh.empty?
+    status 400
+    next { 'error' => 'refresh_token required' }.to_json
+  end
+
+  raw = kv.get("refresh:#{refresh}").__await__
+  if raw.nil?
+    status 401
+    next { 'error' => 'unknown refresh_token' }.to_json
+  end
+
+  begin
+    entry = JSON.parse(raw)
+  rescue JSON::ParserError
+    status 500
+    next { 'error' => 'corrupt refresh entry' }.to_json
+  end
+
+  if entry['exp'].to_i < Time.now.to_i
+    kv.delete("refresh:#{refresh}").__await__
+    status 401
+    next { 'error' => 'refresh_token expired' }.to_json
+  end
+
+  alg = entry['alg'] || 'HS256'
+  sub = entry['sub']
+  sign_key, _ = jwt_keys_for(alg)
+  payload = {
+    'sub'  => sub,
+    'role' => entry['role'] || 'user',
+    'iat'  => Time.now.to_i,
+    'exp'  => Time.now.to_i + JWT_ACCESS_TTL
+  }
+  access_token = JWT.encode(payload, sign_key, alg)
+
+  {
+    'access_token' => access_token,
+    'token_type'   => 'Bearer',
+    'expires_in'   => JWT_ACCESS_TTL,
+    'alg'          => alg
+  }.to_json
+end

--- a/app/routes/fragments/route_025.rb
+++ b/app/routes/fragments/route_025.rb
@@ -1,203 +1,203 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 25 — test /test/crypto
-  get '/test/crypto' do
-    content_type 'application/json'
-    unless crypto_demos_enabled?
-      status 404
-      next { 'error' => 'crypto demos disabled (set HOMURABI_ENABLE_CRYPTO_DEMOS=1 in wrangler vars)' }.to_json
-    end
-    cases = []
-    run = lambda { |label, &blk|
-      result = begin
-        v = blk.call
-        v == false ? { 'pass' => false, 'note' => 'returned false' } : { 'pass' => true }
-      rescue ::Exception => e
-        { 'pass' => false, 'note' => "#{e.class}: #{e.message[0, 200]}" }
-      end
-      cases << result.merge('case' => label)
-    }
-
-    run.call('Digest::SHA256.hexdigest matches CRuby vector') {
-      Digest::SHA256.hexdigest('hello') == '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
-    }
-    run.call('OpenSSL::HMAC SHA256') {
-      OpenSSL::HMAC.hexdigest('SHA256', 'secret', 'hello') == '88aab3ede8d3adf94d26ab90d3bafd4a2083070c3bcce9c014ee04a443847c0b'
-    }
-    run.call('OpenSSL::KDF.pbkdf2_hmac') {
-      d = OpenSSL::KDF.pbkdf2_hmac('password', salt: 'salt-1234', iterations: 4096, length: 32, hash: 'SHA256')
-      d.unpack1('H*') == '2038580f917370fe42b04462a7c26ed17a2e769b44eb6181134243a9dabf0136'
-    }
-    run.call('AES-256-GCM round-trip') {
-      key = SecureRandom.random_bytes(32); iv = SecureRandom.random_bytes(12)
-      e = OpenSSL::Cipher.new('AES-256-GCM').encrypt; e.key = key; e.iv = iv
-      e.update('payload-gcm'); ct = e.final; tag = e.auth_tag
-      d = OpenSSL::Cipher.new('AES-256-GCM').decrypt; d.key = key; d.iv = iv; d.auth_tag = tag
-      d.update(ct); d.final == 'payload-gcm'
-    }
-    run.call('AES-256-CTR streaming') {
-      key = SecureRandom.random_bytes(32); iv = SecureRandom.random_bytes(16)
-      plain = 'streaming-' * 30
-      e = OpenSSL::Cipher.new('AES-256-CTR').encrypt; e.key = key; e.iv = iv
-      ct = ''
-      i = 0
-      while i < plain.length
-        ct = ct + e.update(plain[i, 13]).__await__; i += 13
-      end
-      ct = ct + e.final
-      d = OpenSSL::Cipher.new('AES-256-CTR').decrypt; d.key = key; d.iv = iv
-      d.update(ct).__await__ + d.final == plain
-    }
-    run.call('AES-128-CBC round-trip') {
-      key = SecureRandom.random_bytes(16); iv = SecureRandom.random_bytes(16)
-      e = OpenSSL::Cipher.new('AES-128-CBC').encrypt; e.key = key; e.iv = iv
-      e.update('cbc-test'); ct = e.final
-      d = OpenSSL::Cipher.new('AES-128-CBC').decrypt; d.key = key; d.iv = iv
-      d.update(ct); d.final == 'cbc-test'
-    }
-    run.call('RSA RS256 sign/verify') {
-      r = OpenSSL::PKey::RSA.new(2048)
-      sig = r.sign(OpenSSL::Digest::SHA256.new, 'rs256')
-      r.public_key.verify(OpenSSL::Digest::SHA256.new, sig, 'rs256')
-    }
-    run.call('RSA PS256 sign/verify') {
-      r = OpenSSL::PKey::RSA.new(2048)
-      sig = r.sign_pss('SHA256', 'ps256', salt_length: :digest, mgf1_hash: 'SHA256')
-      r.public_key.verify_pss('SHA256', sig, 'ps256', salt_length: :digest, mgf1_hash: 'SHA256')
-    }
-    run.call('RSA OAEP encrypt/decrypt') {
-      r = OpenSSL::PKey::RSA.new(2048)
-      ct = r.public_key.public_encrypt('oaep-payload')
-      r.private_decrypt(ct) == 'oaep-payload'
-    }
-    run.call('ECDSA ES256 (DER) sign/verify') {
-      ec = OpenSSL::PKey::EC.generate('prime256v1')
-      sig = ec.sign(OpenSSL::Digest::SHA256.new, 'es256')
-      sig.bytes[0] == 0x30 && ec.verify(OpenSSL::Digest::SHA256.new, sig, 'es256')
-    }
-    run.call('ECDSA ES384 sign/verify') {
-      ec = OpenSSL::PKey::EC.generate('secp384r1')
-      sig = ec.sign(OpenSSL::Digest::SHA384.new, 'es384')
-      ec.verify(OpenSSL::Digest::SHA384.new, sig, 'es384')
-    }
-    run.call('ECDSA ES512 sign/verify') {
-      ec = OpenSSL::PKey::EC.generate('secp521r1')
-      sig = ec.sign(OpenSSL::Digest::SHA512.new, 'es512')
-      ec.verify(OpenSSL::Digest::SHA512.new, sig, 'es512')
-    }
-    run.call('ECDH P-256 agreement') {
-      a = OpenSSL::PKey::EC.generate('prime256v1')
-      b = OpenSSL::PKey::EC.generate('prime256v1')
-      a.dh_compute_key(b) == b.dh_compute_key(a)
-    }
-    run.call('Ed25519 sign/verify (EdDSA)') {
-      ed = OpenSSL::PKey::Ed25519.generate
-      sig = ed.sign(nil, 'eddsa')
-      ed.verify(nil, sig, 'eddsa')
-    }
-    run.call('X25519 key agreement') {
-      a = OpenSSL::PKey::X25519.generate
-      b = OpenSSL::PKey::X25519.generate
-      a.dh_compute_key(b) == b.dh_compute_key(a)
-    }
-    run.call('OpenSSL::BN arithmetic') {
-      (OpenSSL::BN.new(123) + OpenSSL::BN.new(456)).to_s == '579' &&
-        OpenSSL::BN.new(3).mod_exp(5, 13).to_s == '9'
-    }
-    run.call('SecureRandom.hex(16) returns 32 hex chars') {
-      SecureRandom.hex(16).length == 32
-    }
-
-    # Phase 8 — JWT self-test. Exercises the vendored jwt gem through
-    # every algorithm against the live Workers runtime so we can prove
-    # RS/PS/ES/EdDSA signatures actually verify on the edge, not just
-    # in the Node test harness.
-    jwt_payload = { 'sub' => 'self-test', 'iat' => Time.now.to_i }
-    jwt_secret  = 'phase8-self-test-secret'
-
-    run.call('JWT HS256 encode/decode round-trip') {
-      tok = JWT.encode(jwt_payload, jwt_secret, 'HS256')
-      dec, = JWT.decode(tok, jwt_secret, true, algorithm: 'HS256')
-      dec['sub'] == 'self-test'
-    }
-    run.call('JWT HS256 tampered signature rejected') {
-      tok = JWT.encode(jwt_payload, jwt_secret, 'HS256')
-      parts = tok.split('.')
-      mid = parts[2].length / 2
-      parts[2] = parts[2][0, mid] + (parts[2][mid] == 'A' ? 'B' : 'A') + parts[2][mid + 1, parts[2].length - mid - 1]
-      raised = false
-      begin
-        JWT.decode(parts.join('.'), jwt_secret, true, algorithm: 'HS256')
-      rescue JWT::VerificationError
-        raised = true
-      end
-      raised
-    }
-
-    rsa = OpenSSL::PKey::RSA.new(2048)
-    run.call('JWT RS256 encode/decode round-trip') {
-      tok = JWT.encode(jwt_payload, rsa, 'RS256')
-      dec, = JWT.decode(tok, rsa.public_key, true, algorithm: 'RS256')
-      dec['sub'] == 'self-test'
-    }
-    run.call('JWT PS256 encode/decode round-trip') {
-      tok = JWT.encode(jwt_payload, rsa, 'PS256')
-      dec, = JWT.decode(tok, rsa.public_key, true, algorithm: 'PS256')
-      dec['sub'] == 'self-test'
-    }
-    run.call('JWT RS256 tampered signature rejected') {
-      tok = JWT.encode(jwt_payload, rsa, 'RS256')
-      parts = tok.split('.')
-      mid = parts[2].length / 2
-      parts[2] = parts[2][0, mid] + (parts[2][mid] == 'A' ? 'B' : 'A') + parts[2][mid + 1, parts[2].length - mid - 1]
-      raised = false
-      begin
-        JWT.decode(parts.join('.'), rsa.public_key, true, algorithm: 'RS256')
-      rescue JWT::VerificationError
-        raised = true
-      end
-      raised
-    }
-
-    ec256 = OpenSSL::PKey::EC.generate('prime256v1')
-    run.call('JWT ES256 encode/decode round-trip') {
-      tok = JWT.encode(jwt_payload, ec256, 'ES256')
-      dec, = JWT.decode(tok, ec256, true, algorithm: 'ES256')
-      dec['sub'] == 'self-test'
-    }
-    ec384 = OpenSSL::PKey::EC.generate('secp384r1')
-    run.call('JWT ES384 encode/decode round-trip') {
-      tok = JWT.encode(jwt_payload, ec384, 'ES384')
-      dec, = JWT.decode(tok, ec384, true, algorithm: 'ES384')
-      dec['sub'] == 'self-test'
-    }
-
-    ed = OpenSSL::PKey::Ed25519.generate
-    run.call('JWT EdDSA encode/decode round-trip') {
-      tok = JWT.encode(jwt_payload, ed, 'EdDSA')
-      dec, = JWT.decode(tok, ed, true, algorithm: 'EdDSA')
-      dec['sub'] == 'self-test'
-    }
-    run.call('JWT EdDSA tampered signature rejected') {
-      tok = JWT.encode(jwt_payload, ed, 'EdDSA')
-      parts = tok.split('.')
-      mid = parts[2].length / 2
-      parts[2] = parts[2][0, mid] + (parts[2][mid] == 'A' ? 'B' : 'A') + parts[2][mid + 1, parts[2].length - mid - 1]
-      raised = false
-      begin
-        JWT.decode(parts.join('.'), ed, true, algorithm: 'EdDSA')
-      rescue JWT::VerificationError
-        raised = true
-      end
-      raised
-    }
-
-    passed = cases.count { |c| c['pass'] }
-    failed = cases.size - passed
-    {
-      'passed' => passed,
-      'failed' => failed,
-      'total'  => cases.size,
-      'cases'  => cases
-    }.to_json
+get '/test/crypto' do
+  content_type 'application/json'
+  unless crypto_demos_enabled?
+    status 404
+    next { 'error' => 'crypto demos disabled (set HOMURABI_ENABLE_CRYPTO_DEMOS=1 in wrangler vars)' }.to_json
   end
+  cases = []
+  run = lambda { |label, &blk|
+    result = begin
+      v = blk.call
+      v == false ? { 'pass' => false, 'note' => 'returned false' } : { 'pass' => true }
+    rescue ::Exception => e
+      { 'pass' => false, 'note' => "#{e.class}: #{e.message[0, 200]}" }
+    end
+    cases << result.merge('case' => label)
+  }
+
+  run.call('Digest::SHA256.hexdigest matches CRuby vector') {
+    Digest::SHA256.hexdigest('hello') == '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+  }
+  run.call('OpenSSL::HMAC SHA256') {
+    OpenSSL::HMAC.hexdigest('SHA256', 'secret', 'hello') == '88aab3ede8d3adf94d26ab90d3bafd4a2083070c3bcce9c014ee04a443847c0b'
+  }
+  run.call('OpenSSL::KDF.pbkdf2_hmac') {
+    d = OpenSSL::KDF.pbkdf2_hmac('password', salt: 'salt-1234', iterations: 4096, length: 32, hash: 'SHA256')
+    d.unpack1('H*') == '2038580f917370fe42b04462a7c26ed17a2e769b44eb6181134243a9dabf0136'
+  }
+  run.call('AES-256-GCM round-trip') {
+    key = SecureRandom.random_bytes(32); iv = SecureRandom.random_bytes(12)
+    e = OpenSSL::Cipher.new('AES-256-GCM').encrypt; e.key = key; e.iv = iv
+    e.update('payload-gcm'); ct = e.final; tag = e.auth_tag
+    d = OpenSSL::Cipher.new('AES-256-GCM').decrypt; d.key = key; d.iv = iv; d.auth_tag = tag
+    d.update(ct); d.final == 'payload-gcm'
+  }
+  run.call('AES-256-CTR streaming') {
+    key = SecureRandom.random_bytes(32); iv = SecureRandom.random_bytes(16)
+    plain = 'streaming-' * 30
+    e = OpenSSL::Cipher.new('AES-256-CTR').encrypt; e.key = key; e.iv = iv
+    ct = ''
+    i = 0
+    while i < plain.length
+      ct = ct + e.update(plain[i, 13]).__await__; i += 13
+    end
+    ct = ct + e.final
+    d = OpenSSL::Cipher.new('AES-256-CTR').decrypt; d.key = key; d.iv = iv
+    d.update(ct).__await__ + d.final == plain
+  }
+  run.call('AES-128-CBC round-trip') {
+    key = SecureRandom.random_bytes(16); iv = SecureRandom.random_bytes(16)
+    e = OpenSSL::Cipher.new('AES-128-CBC').encrypt; e.key = key; e.iv = iv
+    e.update('cbc-test'); ct = e.final
+    d = OpenSSL::Cipher.new('AES-128-CBC').decrypt; d.key = key; d.iv = iv
+    d.update(ct); d.final == 'cbc-test'
+  }
+  run.call('RSA RS256 sign/verify') {
+    r = OpenSSL::PKey::RSA.new(2048)
+    sig = r.sign(OpenSSL::Digest::SHA256.new, 'rs256')
+    r.public_key.verify(OpenSSL::Digest::SHA256.new, sig, 'rs256')
+  }
+  run.call('RSA PS256 sign/verify') {
+    r = OpenSSL::PKey::RSA.new(2048)
+    sig = r.sign_pss('SHA256', 'ps256', salt_length: :digest, mgf1_hash: 'SHA256')
+    r.public_key.verify_pss('SHA256', sig, 'ps256', salt_length: :digest, mgf1_hash: 'SHA256')
+  }
+  run.call('RSA OAEP encrypt/decrypt') {
+    r = OpenSSL::PKey::RSA.new(2048)
+    ct = r.public_key.public_encrypt('oaep-payload')
+    r.private_decrypt(ct) == 'oaep-payload'
+  }
+  run.call('ECDSA ES256 (DER) sign/verify') {
+    ec = OpenSSL::PKey::EC.generate('prime256v1')
+    sig = ec.sign(OpenSSL::Digest::SHA256.new, 'es256')
+    sig.bytes[0] == 0x30 && ec.verify(OpenSSL::Digest::SHA256.new, sig, 'es256')
+  }
+  run.call('ECDSA ES384 sign/verify') {
+    ec = OpenSSL::PKey::EC.generate('secp384r1')
+    sig = ec.sign(OpenSSL::Digest::SHA384.new, 'es384')
+    ec.verify(OpenSSL::Digest::SHA384.new, sig, 'es384')
+  }
+  run.call('ECDSA ES512 sign/verify') {
+    ec = OpenSSL::PKey::EC.generate('secp521r1')
+    sig = ec.sign(OpenSSL::Digest::SHA512.new, 'es512')
+    ec.verify(OpenSSL::Digest::SHA512.new, sig, 'es512')
+  }
+  run.call('ECDH P-256 agreement') {
+    a = OpenSSL::PKey::EC.generate('prime256v1')
+    b = OpenSSL::PKey::EC.generate('prime256v1')
+    a.dh_compute_key(b) == b.dh_compute_key(a)
+  }
+  run.call('Ed25519 sign/verify (EdDSA)') {
+    ed = OpenSSL::PKey::Ed25519.generate
+    sig = ed.sign(nil, 'eddsa')
+    ed.verify(nil, sig, 'eddsa')
+  }
+  run.call('X25519 key agreement') {
+    a = OpenSSL::PKey::X25519.generate
+    b = OpenSSL::PKey::X25519.generate
+    a.dh_compute_key(b) == b.dh_compute_key(a)
+  }
+  run.call('OpenSSL::BN arithmetic') {
+    (OpenSSL::BN.new(123) + OpenSSL::BN.new(456)).to_s == '579' &&
+      OpenSSL::BN.new(3).mod_exp(5, 13).to_s == '9'
+  }
+  run.call('SecureRandom.hex(16) returns 32 hex chars') {
+    SecureRandom.hex(16).length == 32
+  }
+
+  # Phase 8 — JWT self-test. Exercises the vendored jwt gem through
+  # every algorithm against the live Workers runtime so we can prove
+  # RS/PS/ES/EdDSA signatures actually verify on the edge, not just
+  # in the Node test harness.
+  jwt_payload = { 'sub' => 'self-test', 'iat' => Time.now.to_i }
+  jwt_secret  = 'phase8-self-test-secret'
+
+  run.call('JWT HS256 encode/decode round-trip') {
+    tok = JWT.encode(jwt_payload, jwt_secret, 'HS256')
+    dec, = JWT.decode(tok, jwt_secret, true, algorithm: 'HS256')
+    dec['sub'] == 'self-test'
+  }
+  run.call('JWT HS256 tampered signature rejected') {
+    tok = JWT.encode(jwt_payload, jwt_secret, 'HS256')
+    parts = tok.split('.')
+    mid = parts[2].length / 2
+    parts[2] = parts[2][0, mid] + (parts[2][mid] == 'A' ? 'B' : 'A') + parts[2][mid + 1, parts[2].length - mid - 1]
+    raised = false
+    begin
+      JWT.decode(parts.join('.'), jwt_secret, true, algorithm: 'HS256')
+    rescue JWT::VerificationError
+      raised = true
+    end
+    raised
+  }
+
+  rsa = OpenSSL::PKey::RSA.new(2048)
+  run.call('JWT RS256 encode/decode round-trip') {
+    tok = JWT.encode(jwt_payload, rsa, 'RS256')
+    dec, = JWT.decode(tok, rsa.public_key, true, algorithm: 'RS256')
+    dec['sub'] == 'self-test'
+  }
+  run.call('JWT PS256 encode/decode round-trip') {
+    tok = JWT.encode(jwt_payload, rsa, 'PS256')
+    dec, = JWT.decode(tok, rsa.public_key, true, algorithm: 'PS256')
+    dec['sub'] == 'self-test'
+  }
+  run.call('JWT RS256 tampered signature rejected') {
+    tok = JWT.encode(jwt_payload, rsa, 'RS256')
+    parts = tok.split('.')
+    mid = parts[2].length / 2
+    parts[2] = parts[2][0, mid] + (parts[2][mid] == 'A' ? 'B' : 'A') + parts[2][mid + 1, parts[2].length - mid - 1]
+    raised = false
+    begin
+      JWT.decode(parts.join('.'), rsa.public_key, true, algorithm: 'RS256')
+    rescue JWT::VerificationError
+      raised = true
+    end
+    raised
+  }
+
+  ec256 = OpenSSL::PKey::EC.generate('prime256v1')
+  run.call('JWT ES256 encode/decode round-trip') {
+    tok = JWT.encode(jwt_payload, ec256, 'ES256')
+    dec, = JWT.decode(tok, ec256, true, algorithm: 'ES256')
+    dec['sub'] == 'self-test'
+  }
+  ec384 = OpenSSL::PKey::EC.generate('secp384r1')
+  run.call('JWT ES384 encode/decode round-trip') {
+    tok = JWT.encode(jwt_payload, ec384, 'ES384')
+    dec, = JWT.decode(tok, ec384, true, algorithm: 'ES384')
+    dec['sub'] == 'self-test'
+  }
+
+  ed = OpenSSL::PKey::Ed25519.generate
+  run.call('JWT EdDSA encode/decode round-trip') {
+    tok = JWT.encode(jwt_payload, ed, 'EdDSA')
+    dec, = JWT.decode(tok, ed, true, algorithm: 'EdDSA')
+    dec['sub'] == 'self-test'
+  }
+  run.call('JWT EdDSA tampered signature rejected') {
+    tok = JWT.encode(jwt_payload, ed, 'EdDSA')
+    parts = tok.split('.')
+    mid = parts[2].length / 2
+    parts[2] = parts[2][0, mid] + (parts[2][mid] == 'A' ? 'B' : 'A') + parts[2][mid + 1, parts[2].length - mid - 1]
+    raised = false
+    begin
+      JWT.decode(parts.join('.'), ed, true, algorithm: 'EdDSA')
+    rescue JWT::VerificationError
+      raised = true
+    end
+    raised
+  }
+
+  passed = cases.count { |c| c['pass'] }
+  failed = cases.size - passed
+  {
+    'passed' => passed,
+    'failed' => failed,
+    'total'  => cases.size,
+    'cases'  => cases
+  }.to_json
+end

--- a/app/routes/fragments/route_026.rb
+++ b/app/routes/fragments/route_026.rb
@@ -1,71 +1,71 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 26 — demo /demo/crypto
-  get '/demo/crypto' do
-    content_type 'application/json'
-    unless crypto_demos_enabled?
-      status 404
-      next { 'error' => 'crypto demos disabled (set HOMURABI_ENABLE_CRYPTO_DEMOS=1 in wrangler vars)' }.to_json
-    end
-
-    # 1) Digest one-shots
-    sha256 = Digest::SHA256.hexdigest('hello, edge')
-    sha512 = Digest::SHA512.hexdigest('hello, edge')
-
-    # 2) HMAC (JWT HS256 signing input shape)
-    hmac_hex = OpenSSL::HMAC.hexdigest('SHA256', 'super-secret', 'hello, edge')
-
-    # 3) AES-256-GCM round-trip with random key/iv (Web Crypto subtle async)
-    key   = SecureRandom.random_bytes(32)
-    iv    = SecureRandom.random_bytes(12)
-    plain = 'phase 7 cipher payload'
-    enc = OpenSSL::Cipher.new('AES-256-GCM').encrypt
-    enc.key = key; enc.iv = iv
-    enc.update(plain)
-    ct  = enc.final
-    tag = enc.auth_tag
-    dec = OpenSSL::Cipher.new('AES-256-GCM').decrypt
-    dec.key = key; dec.iv = iv; dec.auth_tag = tag
-    dec.update(ct)
-    recovered = dec.final
-
-    # 4) RSA sign + verify (Web Crypto subtle async)
-    rsa = OpenSSL::PKey::RSA.new(2048)
-    msg = 'phase 7 rsa payload'
-    sig = rsa.sign(OpenSSL::Digest::SHA256.new, msg)
-    rsa_ok = rsa.public_key.verify(OpenSSL::Digest::SHA256.new, sig, msg)
-
-    # 5) PBKDF2 derived key
-    derived = OpenSSL::KDF.pbkdf2_hmac(
-      'p@ssw0rd', salt: 'phase7-salt', iterations: 4096, length: 32, hash: 'SHA256'
-    )
-
-    # 6) Hand-rolled HS256 JWT (proof Phase 8 jwt gem will work)
-    header  = { 'alg' => 'HS256', 'typ' => 'JWT' }
-    payload = { 'sub' => 'demo', 'iat' => Time.now.to_i }
-    enc_b64 = lambda { |obj| Base64.urlsafe_encode64(obj.to_json).delete('=') }
-    signing_input = enc_b64.call(header) + '.' + enc_b64.call(payload)
-    sig_bin = OpenSSL::HMAC.digest('SHA256', 'jwt-secret', signing_input)
-    token   = signing_input + '.' + Base64.urlsafe_encode64(sig_bin).delete('=')
-
-    {
-      'demo'              => 'Phase 7 — node:crypto-backed Ruby crypto',
-      'sha256_hello_edge' => sha256,
-      'sha512_hello_edge' => sha512,
-      'hmac_sha256_hex'   => hmac_hex,
-      'aes_gcm_round_trip' => {
-        'plain'     => plain,
-        'recovered' => recovered,
-        'match'     => recovered == plain,
-        'tag_b64'   => Base64.strict_encode64(tag)
-      },
-      'rsa_sign_verify'   => { 'ok' => rsa_ok, 'sig_len_bytes' => sig.bytesize },
-      'pbkdf2_sha256_hex' => derived.unpack1('H*'),
-      'jwt_hs256'         => token,
-      'secure_random'     => {
-        'hex'             => SecureRandom.hex(16),
-        'urlsafe_base64'  => SecureRandom.urlsafe_base64(24),
-        'uuid'            => SecureRandom.uuid
-      }
-    }.to_json
+get '/demo/crypto' do
+  content_type 'application/json'
+  unless crypto_demos_enabled?
+    status 404
+    next { 'error' => 'crypto demos disabled (set HOMURABI_ENABLE_CRYPTO_DEMOS=1 in wrangler vars)' }.to_json
   end
+
+  # 1) Digest one-shots
+  sha256 = Digest::SHA256.hexdigest('hello, edge')
+  sha512 = Digest::SHA512.hexdigest('hello, edge')
+
+  # 2) HMAC (JWT HS256 signing input shape)
+  hmac_hex = OpenSSL::HMAC.hexdigest('SHA256', 'super-secret', 'hello, edge')
+
+  # 3) AES-256-GCM round-trip with random key/iv (Web Crypto subtle async)
+  key   = SecureRandom.random_bytes(32)
+  iv    = SecureRandom.random_bytes(12)
+  plain = 'phase 7 cipher payload'
+  enc = OpenSSL::Cipher.new('AES-256-GCM').encrypt
+  enc.key = key; enc.iv = iv
+  enc.update(plain)
+  ct  = enc.final
+  tag = enc.auth_tag
+  dec = OpenSSL::Cipher.new('AES-256-GCM').decrypt
+  dec.key = key; dec.iv = iv; dec.auth_tag = tag
+  dec.update(ct)
+  recovered = dec.final
+
+  # 4) RSA sign + verify (Web Crypto subtle async)
+  rsa = OpenSSL::PKey::RSA.new(2048)
+  msg = 'phase 7 rsa payload'
+  sig = rsa.sign(OpenSSL::Digest::SHA256.new, msg)
+  rsa_ok = rsa.public_key.verify(OpenSSL::Digest::SHA256.new, sig, msg)
+
+  # 5) PBKDF2 derived key
+  derived = OpenSSL::KDF.pbkdf2_hmac(
+    'p@ssw0rd', salt: 'phase7-salt', iterations: 4096, length: 32, hash: 'SHA256'
+  )
+
+  # 6) Hand-rolled HS256 JWT (proof Phase 8 jwt gem will work)
+  header  = { 'alg' => 'HS256', 'typ' => 'JWT' }
+  payload = { 'sub' => 'demo', 'iat' => Time.now.to_i }
+  enc_b64 = lambda { |obj| Base64.urlsafe_encode64(obj.to_json).delete('=') }
+  signing_input = enc_b64.call(header) + '.' + enc_b64.call(payload)
+  sig_bin = OpenSSL::HMAC.digest('SHA256', 'jwt-secret', signing_input)
+  token   = signing_input + '.' + Base64.urlsafe_encode64(sig_bin).delete('=')
+
+  {
+    'demo'              => 'Phase 7 — node:crypto-backed Ruby crypto',
+    'sha256_hello_edge' => sha256,
+    'sha512_hello_edge' => sha512,
+    'hmac_sha256_hex'   => hmac_hex,
+    'aes_gcm_round_trip' => {
+      'plain'     => plain,
+      'recovered' => recovered,
+      'match'     => recovered == plain,
+      'tag_b64'   => Base64.strict_encode64(tag)
+    },
+    'rsa_sign_verify'   => { 'ok' => rsa_ok, 'sig_len_bytes' => sig.bytesize },
+    'pbkdf2_sha256_hex' => derived.unpack1('H*'),
+    'jwt_hs256'         => token,
+    'secure_random'     => {
+      'hex'             => SecureRandom.hex(16),
+      'urlsafe_base64'  => SecureRandom.urlsafe_base64(24),
+      'uuid'            => SecureRandom.uuid
+    }
+  }.to_json
+end

--- a/app/routes/fragments/route_027.rb
+++ b/app/routes/fragments/route_027.rb
@@ -1,20 +1,20 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 27 — test /test/scheduled
-  get '/test/scheduled' do
-    content_type 'application/json'
-    unless scheduled_demos_enabled?
-      status 404
-      next { 'error' => 'scheduled demos disabled (set HOMURABI_ENABLE_SCHEDULED_DEMOS=1 in wrangler vars)' }.to_json
-    end
-    {
-      'jobs' => App.scheduled_jobs.map do |job|
-        {
-          'name' => job.name,
-          'cron' => job.cron,
-          'file' => job.file,
-          'line' => job.line
-        }
-      end
-    }.to_json
+get '/test/scheduled' do
+  content_type 'application/json'
+  unless scheduled_demos_enabled?
+    status 404
+    next { 'error' => 'scheduled demos disabled (set HOMURABI_ENABLE_SCHEDULED_DEMOS=1 in wrangler vars)' }.to_json
   end
+  {
+    'jobs' => App.scheduled_jobs.map do |job|
+      {
+        'name' => job.name,
+        'cron' => job.cron,
+        'file' => job.file,
+        'line' => job.line
+      }
+    end
+  }.to_json
+end

--- a/app/routes/fragments/route_028.rb
+++ b/app/routes/fragments/route_028.rb
@@ -1,25 +1,25 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 28 — test /test/scheduled/run
-  post '/test/scheduled/run' do
-    content_type 'application/json'
-    unless scheduled_demos_enabled?
-      status 404
-      next({ 'error' => 'scheduled demos disabled (set HOMURABI_ENABLE_SCHEDULED_DEMOS=1 in wrangler vars)' }.to_json)
-    end
-    cron = params['cron'].to_s
-    if cron.empty?
-      status 400
-      next({ 'error' => 'missing cron query param (e.g. ?cron=*/5%20*%20*%20*%20*)' }.to_json)
-    end
-    # Use the same dispatcher the Workers runtime invokes. Pass the
-    # JS env / ctx so D1 / KV writes hit the live bindings. The
-    # dispatcher is async (it `__await__`s each job's body), so we
-    # MUST `__await__` its return Promise before serialising the
-    # result — otherwise the inner D1 / KV writes get torn down when
-    # the HTTP response is sent. The literal `__await__` token is
-    # what Opal scans for to emit a JS `await`.
-    event  = Cloudflare::ScheduledEvent.new(cron: cron, scheduled_time: Time.now)
-    result = App.dispatch_scheduled(event, env['cloudflare.env'], env['cloudflare.ctx'])
-    result.merge('cron' => cron, 'registered_crons' => App.scheduled_jobs.map(&:cron)).to_json
+post '/test/scheduled/run' do
+  content_type 'application/json'
+  unless scheduled_demos_enabled?
+    status 404
+    next({ 'error' => 'scheduled demos disabled (set HOMURABI_ENABLE_SCHEDULED_DEMOS=1 in wrangler vars)' }.to_json)
   end
+  cron = params['cron'].to_s
+  if cron.empty?
+    status 400
+    next({ 'error' => 'missing cron query param (e.g. ?cron=*/5%20*%20*%20*%20*)' }.to_json)
+  end
+  # Use the same dispatcher the Workers runtime invokes. Pass the
+  # JS env / ctx so D1 / KV writes hit the live bindings. The
+  # dispatcher is async (it `__await__`s each job's body), so we
+  # MUST `__await__` its return Promise before serialising the
+  # result — otherwise the inner D1 / KV writes get torn down when
+  # the HTTP response is sent. The literal `__await__` token is
+  # what Opal scans for to emit a JS `await`.
+  event  = Cloudflare::ScheduledEvent.new(cron: cron, scheduled_time: Time.now)
+  result = App.dispatch_scheduled(event, env['cloudflare.env'], env['cloudflare.ctx'])
+  result.merge('cron' => cron, 'registered_crons' => App.scheduled_jobs.map(&:cron)).to_json
+end

--- a/app/routes/fragments/route_029.rb
+++ b/app/routes/fragments/route_029.rb
@@ -1,9 +1,9 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 29 — login /login
-  get '/login' do
-    @title = 'Login — homurabi'
-    @login_error = nil
-    @content = erb :login
-    erb :layout
-  end
+get '/login' do
+  @title = 'Login — homurabi'
+  @login_error = nil
+  @content = erb :login
+  erb :layout
+end

--- a/app/routes/fragments/route_030.rb
+++ b/app/routes/fragments/route_030.rb
@@ -24,13 +24,13 @@
     # mint_session_cookie is sync (HMAC-SHA256 via node:crypto).
     # Keeping the route body sync lets `redirect` work normally.
     token = mint_session_cookie(username)
-    response.set_cookie(SESSION_COOKIE_NAME, {
+    response.set_cookie(App::SESSION_COOKIE_NAME, {
       value: token,
       path: '/',
       httponly: true,
       secure: request.scheme == 'https',
       same_site: :lax,
-      max_age: SESSION_COOKIE_TTL
+      max_age: App::SESSION_COOKIE_TTL
     })
     # 303 See Other — explicitly tells the client to follow up with
     # GET, avoiding any ambiguous POST-replay semantics around 302.

--- a/app/routes/fragments/route_030.rb
+++ b/app/routes/fragments/route_030.rb
@@ -1,38 +1,38 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 30 — login /login
-  post '/login' do
-    username = params['username'].to_s.strip
-    return_to = params['return_to'].to_s
-    # Reject protocol-relative (`//evil.example`) and anything with
-    # whitespace/newlines so the Location: header stays strictly
-    # within-site. `\A/(?!/)\S*\z` → starts with single `/`, no `//`
-    # prefix, no whitespace.
-    return_to = '/chat' unless return_to.match?(%r{\A/(?!/)\S*\z})
+post '/login' do
+  username = params['username'].to_s.strip
+  return_to = params['return_to'].to_s
+  # Reject protocol-relative (`//evil.example`) and anything with
+  # whitespace/newlines so the Location: header stays strictly
+  # within-site. `\A/(?!/)\S*\z` → starts with single `/`, no `//`
+  # prefix, no whitespace.
+  return_to = '/chat' unless return_to.match?(%r{\A/(?!/)\S*\z})
 
-    # `:` is the session cookie payload delimiter (`username:exp`
-    # → base64url → HMAC). Allowing `:` in the username would
-    # truncate it on verification (split(':', 2)), so the
-    # displayed/stored user wouldn't match what was entered.
-    if username.empty? || username.length > 64 || username.include?(':')
-      @title = 'Login — homurabi'
-      @login_error = 'username is required (1-64 chars, no colon)'
-      @content = erb :login
-      next erb :layout
-    end
-
-    # mint_session_cookie is sync (HMAC-SHA256 via node:crypto).
-    # Keeping the route body sync lets `redirect` work normally.
-    token = mint_session_cookie(username)
-    response.set_cookie(App::SESSION_COOKIE_NAME, {
-      value: token,
-      path: '/',
-      httponly: true,
-      secure: request.scheme == 'https',
-      same_site: :lax,
-      max_age: App::SESSION_COOKIE_TTL
-    })
-    # 303 See Other — explicitly tells the client to follow up with
-    # GET, avoiding any ambiguous POST-replay semantics around 302.
-    redirect return_to, 303
+  # `:` is the session cookie payload delimiter (`username:exp`
+  # → base64url → HMAC). Allowing `:` in the username would
+  # truncate it on verification (split(':', 2)), so the
+  # displayed/stored user wouldn't match what was entered.
+  if username.empty? || username.length > 64 || username.include?(':')
+    @title = 'Login — homurabi'
+    @login_error = 'username is required (1-64 chars, no colon)'
+    @content = erb :login
+    next erb :layout
   end
+
+  # mint_session_cookie is sync (HMAC-SHA256 via node:crypto).
+  # Keeping the route body sync lets `redirect` work normally.
+  token = mint_session_cookie(username)
+  response.set_cookie(App::SESSION_COOKIE_NAME, {
+    value: token,
+    path: '/',
+    httponly: true,
+    secure: request.scheme == 'https',
+    same_site: :lax,
+    max_age: App::SESSION_COOKIE_TTL
+  })
+  # 303 See Other — explicitly tells the client to follow up with
+  # GET, avoiding any ambiguous POST-replay semantics around 302.
+  redirect return_to, 303
+end

--- a/app/routes/fragments/route_031.rb
+++ b/app/routes/fragments/route_031.rb
@@ -1,7 +1,7 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 31 — login /logout
-  get '/logout' do
-    response.delete_cookie(App::SESSION_COOKIE_NAME, path: '/')
-    redirect '/'
-  end
+get '/logout' do
+  response.delete_cookie(App::SESSION_COOKIE_NAME, path: '/')
+  redirect '/'
+end

--- a/app/routes/fragments/route_031.rb
+++ b/app/routes/fragments/route_031.rb
@@ -2,6 +2,6 @@
 # frozen_string_literal: true
 # Route fragment 31 — login /logout
   get '/logout' do
-    response.delete_cookie(SESSION_COOKIE_NAME, path: '/')
+    response.delete_cookie(App::SESSION_COOKIE_NAME, path: '/')
     redirect '/'
   end

--- a/app/routes/fragments/route_032.rb
+++ b/app/routes/fragments/route_032.rb
@@ -1,24 +1,24 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 32 — login /chat
-  get '/chat' do
-    # /chat's body is async (load_chat_history is auto-awaited), so
-    # `redirect` (which throws :halt) would surface as
-    # `UncaughtThrowError: uncaught throw "halt"` past the async
-    # boundary. Set Location on the response (captured into
-    # `js_headers` by build_js_response before any await), then
-    # return a 2-element `[status, body]` tuple that the JS
-    # override in `lib/cloudflare_workers.rb` recognises.
-    unless current_session_user
-      response['Location'] = "/login?return_to=#{Rack::Utils.escape('/chat')}"
-      next [302, '']
-    end
-
-    @title = 'homurabi /chat — Workers AI'
-    @primary_model  = CHAT_MODELS[:primary]
-    @fallback_model = CHAT_MODELS[:fallback]
-    @session_id = normalize_session_id(params['session'])
-    @history = ai_demos_enabled? ? load_chat_history(@session_id) : []
-    @content = erb :chat
-    erb :layout
+get '/chat' do
+  # /chat's body is async (load_chat_history is auto-awaited), so
+  # `redirect` (which throws :halt) would surface as
+  # `UncaughtThrowError: uncaught throw "halt"` past the async
+  # boundary. Set Location on the response (captured into
+  # `js_headers` by build_js_response before any await), then
+  # return a 2-element `[status, body]` tuple that the JS
+  # override in `lib/cloudflare_workers.rb` recognises.
+  unless current_session_user
+    response['Location'] = "/login?return_to=#{Rack::Utils.escape('/chat')}"
+    next [302, '']
   end
+
+  @title = 'homurabi /chat — Workers AI'
+  @primary_model  = CHAT_MODELS[:primary]
+  @fallback_model = CHAT_MODELS[:fallback]
+  @session_id = normalize_session_id(params['session'])
+  @history = ai_demos_enabled? ? load_chat_history(@session_id) : []
+  @content = erb :chat
+  erb :layout
+end

--- a/app/routes/fragments/route_033.rb
+++ b/app/routes/fragments/route_033.rb
@@ -1,14 +1,14 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 33 — api /api/chat/health
-  get '/api/chat/health' do
-    content_type 'application/json'
-    {
-      'ok'             => true,
-      'demos_enabled'  => ai_demos_enabled?,
-      'ai_bound'       => ai_binding?,
-      'kv_bound'       => !kv.nil?,
-      'primary_model'  => CHAT_MODELS[:primary],
-      'fallback_model' => CHAT_MODELS[:fallback]
-    }.to_json
-  end
+get '/api/chat/health' do
+  content_type 'application/json'
+  {
+    'ok'             => true,
+    'demos_enabled'  => ai_demos_enabled?,
+    'ai_bound'       => ai_binding?,
+    'kv_bound'       => !kv.nil?,
+    'primary_model'  => CHAT_MODELS[:primary],
+    'fallback_model' => CHAT_MODELS[:fallback]
+  }.to_json
+end

--- a/app/routes/fragments/route_034.rb
+++ b/app/routes/fragments/route_034.rb
@@ -1,148 +1,148 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 34 — api /api/chat/messages
-  post '/api/chat/messages' do
-    content_type 'application/json'
-    gate = ai_demos_block_or_nil
-    next gate if gate
-    # Inline JWT verification — early-exit with explicit `status` and
-    # `next` (the same pattern Phase 8's /api/me uses successfully).
-    # We deliberately do NOT call `Sinatra::JwtAuth#authenticate!`
-    # because that helper uses `halt` which throws past Opal's async
-    # boundary (Sinatra's `catch :halt` cannot see a JS Promise
-    # rejection). And we keep the token decode outside any helper so
-    # the `status N` call sits in the same `dispatch!` frame as the
-    # `next` — pulling it into a helper made the response leak out
-    # as 200 in earlier iterations.
-    auth_header = request.env['HTTP_AUTHORIZATION'].to_s
-    parts = auth_header.split(' ', 2)
-    if parts.length != 2 || parts[0].downcase != 'bearer'
-      status 401
-      next({ 'error' => 'unauthorized', 'reason' => 'missing bearer token' }.to_json)
-    end
-    auth_token = parts[1].strip
-    if auth_token.empty?
-      status 401
-      next({ 'error' => 'unauthorized', 'reason' => 'missing bearer token' }.to_json)
-    end
-    # JWT verify (post-await). Setting `status N` after the await would
-    # not take effect because Sinatra's `invoke` snapshots
-    # `response.status` synchronously when it sees a Promise body, so
-    # any mutation that happens later than that snapshot is lost. We
-    # work around it by returning `[status, body]` from the route — the
-    # homurabi patch in `build_js_response` detects that single-chunk
-    # shape and uses the embedded status when constructing the JS
-    # Response.
-    decode_err = `(async function(){
-      try {
-        await #{JWT.decode(auth_token, settings.jwt_secret, true, algorithm: settings.jwt_algorithm)};
-        return null;
-      } catch (e) {
-        var msg = (e && e.$message) ? e.$message() : (e && e.message) ? e.message : String(e);
-        return 'invalid token: ' + String(msg);
-      }
-    })()`.__await__
-    is_failure = `(#{decode_err} != null && #{decode_err} !== undefined)`
-    if is_failure
-      err_msg = decode_err.to_s
-      next [401, { 'error' => 'unauthorized', 'reason' => err_msg }.to_json]
-    end
-    bgate = ai_binding_block_or_nil
-    next bgate if bgate
+post '/api/chat/messages' do
+  content_type 'application/json'
+  gate = ai_demos_block_or_nil
+  next gate if gate
+  # Inline JWT verification — early-exit with explicit `status` and
+  # `next` (the same pattern Phase 8's /api/me uses successfully).
+  # We deliberately do NOT call `Sinatra::JwtAuth#authenticate!`
+  # because that helper uses `halt` which throws past Opal's async
+  # boundary (Sinatra's `catch :halt` cannot see a JS Promise
+  # rejection). And we keep the token decode outside any helper so
+  # the `status N` call sits in the same `dispatch!` frame as the
+  # `next` — pulling it into a helper made the response leak out
+  # as 200 in earlier iterations.
+  auth_header = request.env['HTTP_AUTHORIZATION'].to_s
+  parts = auth_header.split(' ', 2)
+  if parts.length != 2 || parts[0].downcase != 'bearer'
+    status 401
+    next({ 'error' => 'unauthorized', 'reason' => 'missing bearer token' }.to_json)
+  end
+  auth_token = parts[1].strip
+  if auth_token.empty?
+    status 401
+    next({ 'error' => 'unauthorized', 'reason' => 'missing bearer token' }.to_json)
+  end
+  # JWT verify (post-await). Setting `status N` after the await would
+  # not take effect because Sinatra's `invoke` snapshots
+  # `response.status` synchronously when it sees a Promise body, so
+  # any mutation that happens later than that snapshot is lost. We
+  # work around it by returning `[status, body]` from the route — the
+  # homurabi patch in `build_js_response` detects that single-chunk
+  # shape and uses the embedded status when constructing the JS
+  # Response.
+  decode_err = `(async function(){
+    try {
+      await #{JWT.decode(auth_token, settings.jwt_secret, true, algorithm: settings.jwt_algorithm)};
+      return null;
+    } catch (e) {
+      var msg = (e && e.$message) ? e.$message() : (e && e.message) ? e.message : String(e);
+      return 'invalid token: ' + String(msg);
+    }
+  })()`.__await__
+  is_failure = `(#{decode_err} != null && #{decode_err} !== undefined)`
+  if is_failure
+    err_msg = decode_err.to_s
+    next [401, { 'error' => 'unauthorized', 'reason' => err_msg }.to_json]
+  end
+  bgate = ai_binding_block_or_nil
+  next bgate if bgate
 
-    body = parse_json_body
-    session_id = normalize_session_id(body['session'])
-    user_text  = body['content'].to_s
-    if user_text.strip.empty?
-      status 400
-      next({ 'error' => 'content required' }.to_json)
-    end
+  body = parse_json_body
+  session_id = normalize_session_id(body['session'])
+  user_text  = body['content'].to_s
+  if user_text.strip.empty?
+    status 400
+    next({ 'error' => 'content required' }.to_json)
+  end
 
-    requested_model = body['model'].to_s
-    primary  = CHAT_MODELS[:primary]
-    fallback = CHAT_MODELS[:fallback]
-    # Allow either of the two configured models. Anything else is
-    # rejected so a client can't run up neuron costs on arbitrary models.
-    model = if requested_model == primary || requested_model == fallback
-              requested_model
-            else
-              primary
-            end
+  requested_model = body['model'].to_s
+  primary  = CHAT_MODELS[:primary]
+  fallback = CHAT_MODELS[:fallback]
+  # Allow either of the two configured models. Anything else is
+  # rejected so a client can't run up neuron costs on arbitrary models.
+  model = if requested_model == primary || requested_model == fallback
+            requested_model
+          else
+            primary
+          end
 
-    # Helper methods that internally call `__await__` on a binding
-    # (KV / D1 / AI) compile to async JS functions, so each helper
-    # call must be `__await__`'d at the call site to unwrap the
-    # returned Promise. Without the explicit await, `history` would
-    # be a PromiseV2 and downstream `JSON.parse` / Array iteration
-    # would crash with "undefined method `each` for PromiseV2".
-    history = load_chat_history(session_id)
-    messages = build_ai_messages(history, user_text)
+  # Helper methods that internally call `__await__` on a binding
+  # (KV / D1 / AI) compile to async JS functions, so each helper
+  # call must be `__await__`'d at the call site to unwrap the
+  # returned Promise. Without the explicit await, `history` would
+  # be a PromiseV2 and downstream `JSON.parse` / Array iteration
+  # would crash with "undefined method `each` for PromiseV2".
+  history = load_chat_history(session_id)
+  messages = build_ai_messages(history, user_text)
 
-    started_at = Time.now.to_f
-    used_model = model
-    used_fallback = false
-    reply_text = nil
-    ai_error  = nil
+  started_at = Time.now.to_f
+  used_model = model
+  used_fallback = false
+  reply_text = nil
+  ai_error  = nil
 
+  begin
+    result = Cloudflare::AI.run(
+      model,
+      # max_tokens raised to 1024 because OpenAI-style models (Gemma 4,
+      # gpt-oss-*) report `finish_reason: "length"` and surface the
+      # visible answer in `message.reasoning` instead of `content` when
+      # truncated. 1024 is generous enough for most chat replies and
+      # still well under Workers' 30s wall-time budget.
+      { messages: messages, max_tokens: 1024 },
+      binding: ai_binding
+    )
+    reply_text = App.extract_ai_text(result).strip
+    raise Cloudflare::AIError.new('empty response', model: model) if reply_text.empty?
+  rescue Cloudflare::AIError => e
+    ai_error = e
+  end
+
+  # Fallback: if the primary model fails or returns empty, retry with
+  # the secondary model exactly once before surfacing an error.
+  if reply_text.nil? || reply_text.empty?
+    used_fallback = true
+    used_model = (model == primary) ? fallback : primary
     begin
       result = Cloudflare::AI.run(
-        model,
-        # max_tokens raised to 1024 because OpenAI-style models (Gemma 4,
-        # gpt-oss-*) report `finish_reason: "length"` and surface the
-        # visible answer in `message.reasoning` instead of `content` when
-        # truncated. 1024 is generous enough for most chat replies and
-        # still well under Workers' 30s wall-time budget.
+        used_model,
         { messages: messages, max_tokens: 1024 },
         binding: ai_binding
       )
       reply_text = App.extract_ai_text(result).strip
-      raise Cloudflare::AIError.new('empty response', model: model) if reply_text.empty?
     rescue Cloudflare::AIError => e
-      ai_error = e
+      status 502
+      next({ 'error' => 'workers AI call failed', 'detail' => e.message, 'fallback_error' => true }.to_json)
     end
-
-    # Fallback: if the primary model fails or returns empty, retry with
-    # the secondary model exactly once before surfacing an error.
     if reply_text.nil? || reply_text.empty?
-      used_fallback = true
-      used_model = (model == primary) ? fallback : primary
-      begin
-        result = Cloudflare::AI.run(
-          used_model,
-          { messages: messages, max_tokens: 1024 },
-          binding: ai_binding
-        )
-        reply_text = App.extract_ai_text(result).strip
-      rescue Cloudflare::AIError => e
-        status 502
-        next({ 'error' => 'workers AI call failed', 'detail' => e.message, 'fallback_error' => true }.to_json)
-      end
-      if reply_text.nil? || reply_text.empty?
-        status 502
-        next({ 'error' => 'workers AI returned empty response on both primary and fallback' }.to_json)
-      end
+      status 502
+      next({ 'error' => 'workers AI returned empty response on both primary and fallback' }.to_json)
     end
-
-    elapsed_ms = ((Time.now.to_f - started_at) * 1000).to_i
-    new_history = history + [
-      { 'role' => 'user',      'content' => user_text },
-      { 'role' => 'assistant', 'content' => reply_text }
-    ]
-    save_chat_history(session_id, new_history)
-
-    {
-      'ok'           => true,
-      'session'      => session_id,
-      'model'        => used_model,
-      'used_fallback'=> used_fallback,
-      'elapsed_ms'   => elapsed_ms,
-      'reply'        => reply_text,
-      # Phase 11B follow-up: pre-rendered HTML so the client can
-      # `innerHTML = reply_html` to show Markdown formatting (bullet
-      # lists, bold, code fences, links). Safe to insert because
-      # `HomurabiMarkdown.render` HTML-escapes the input first and
-      # restricts link hrefs to http/https/mailto/relative.
-      'reply_html'   => markdown_html(reply_text),
-      'history_len'  => new_history.size
-    }.to_json
   end
+
+  elapsed_ms = ((Time.now.to_f - started_at) * 1000).to_i
+  new_history = history + [
+    { 'role' => 'user',      'content' => user_text },
+    { 'role' => 'assistant', 'content' => reply_text }
+  ]
+  save_chat_history(session_id, new_history)
+
+  {
+    'ok'           => true,
+    'session'      => session_id,
+    'model'        => used_model,
+    'used_fallback'=> used_fallback,
+    'elapsed_ms'   => elapsed_ms,
+    'reply'        => reply_text,
+    # Phase 11B follow-up: pre-rendered HTML so the client can
+    # `innerHTML = reply_html` to show Markdown formatting (bullet
+    # lists, bold, code fences, links). Safe to insert because
+    # `HomurabiMarkdown.render` HTML-escapes the input first and
+    # restricts link hrefs to http/https/mailto/relative.
+    'reply_html'   => markdown_html(reply_text),
+    'history_len'  => new_history.size
+  }.to_json
+end

--- a/app/routes/fragments/route_035.rb
+++ b/app/routes/fragments/route_035.rb
@@ -1,33 +1,33 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 35 — api /api/chat/messages
-  get '/api/chat/messages' do
-    content_type 'application/json'
-    gate = ai_demos_block_or_nil
-    next gate if gate
-    auth = chat_verify_token!
-    if auth['ok'] != true
-      # See the long comment in POST /api/chat/messages for why we
-      # return [status, body] instead of using `status N; next body`
-      # — Sinatra snapshots response.status before the await resolves,
-      # so any later mutation is lost.
-      next [auth['status'].to_i, auth['body']]
-    end
-    session_id = normalize_session_id(params['session'])
-    history = load_chat_history(session_id)
-    # Include a pre-rendered HTML for each message so the client can
-    # show Markdown-formatted history without re-running a JS parser.
-    history_enriched = history.map do |m|
-      role = m['role'].to_s
-      content = m['content'].to_s
-      item = { 'role' => role, 'content' => content }
-      # Only assistant replies are converted — user messages are
-      # authored text and stay as-is to preserve the exact payload.
-      item['content_html'] = markdown_html(content) if role == 'assistant'
-      item
-    end
-    {
-      'session' => session_id,
-      'history' => history_enriched
-    }.to_json
+get '/api/chat/messages' do
+  content_type 'application/json'
+  gate = ai_demos_block_or_nil
+  next gate if gate
+  auth = chat_verify_token!
+  if auth['ok'] != true
+    # See the long comment in POST /api/chat/messages for why we
+    # return [status, body] instead of using `status N; next body`
+    # — Sinatra snapshots response.status before the await resolves,
+    # so any later mutation is lost.
+    next [auth['status'].to_i, auth['body']]
   end
+  session_id = normalize_session_id(params['session'])
+  history = load_chat_history(session_id)
+  # Include a pre-rendered HTML for each message so the client can
+  # show Markdown-formatted history without re-running a JS parser.
+  history_enriched = history.map do |m|
+    role = m['role'].to_s
+    content = m['content'].to_s
+    item = { 'role' => role, 'content' => content }
+    # Only assistant replies are converted — user messages are
+    # authored text and stay as-is to preserve the exact payload.
+    item['content_html'] = markdown_html(content) if role == 'assistant'
+    item
+  end
+  {
+    'session' => session_id,
+    'history' => history_enriched
+  }.to_json
+end

--- a/app/routes/fragments/route_036.rb
+++ b/app/routes/fragments/route_036.rb
@@ -1,19 +1,19 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 36 — api /api/chat/messages
-  delete '/api/chat/messages' do
-    content_type 'application/json'
-    gate = ai_demos_block_or_nil
-    next gate if gate
-    auth = chat_verify_token!
-    if auth['ok'] != true
-      # See the long comment in POST /api/chat/messages for why we
-      # return [status, body] instead of using `status N; next body`
-      # — Sinatra snapshots response.status before the await resolves,
-      # so any later mutation is lost.
-      next [auth['status'].to_i, auth['body']]
-    end
-    session_id = normalize_session_id(params['session'])
-    clear_chat_history(session_id)
-    { 'ok' => true, 'session' => session_id, 'cleared' => true }.to_json
+delete '/api/chat/messages' do
+  content_type 'application/json'
+  gate = ai_demos_block_or_nil
+  next gate if gate
+  auth = chat_verify_token!
+  if auth['ok'] != true
+    # See the long comment in POST /api/chat/messages for why we
+    # return [status, body] instead of using `status N; next body`
+    # — Sinatra snapshots response.status before the await resolves,
+    # so any later mutation is lost.
+    next [auth['status'].to_i, auth['body']]
   end
+  session_id = normalize_session_id(params['session'])
+  clear_chat_history(session_id)
+  { 'ok' => true, 'session' => session_id, 'cleared' => true }.to_json
+end

--- a/app/routes/fragments/route_037.rb
+++ b/app/routes/fragments/route_037.rb
@@ -1,27 +1,27 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 37 — test /test/ai/debug
-  get '/test/ai/debug' do
-    content_type 'application/json'
-    unless ai_demos_enabled? && ai_binding?
-      status 404
-      next({ 'error' => 'disabled' }.to_json)
-    end
-    model = params['model'] || CHAT_MODELS[:primary]
-    out = Cloudflare::AI.run(
-      model,
-      { messages: [
-        { role: 'system', content: 'reply with a short Japanese greeting' },
-        { role: 'user',   content: 'こんにちは' }
-      ], max_tokens: 64 },
-      binding: ai_binding
-    )
-    {
-      'model'    => model,
-      'class'    => out.class.to_s,
-      'is_hash'  => out.is_a?(Hash),
-      'keys'     => out.is_a?(Hash) ? out.keys : nil,
-      'extracted'=> App.extract_ai_text(out),
-      'raw'      => out
-    }.to_json
+get '/test/ai/debug' do
+  content_type 'application/json'
+  unless ai_demos_enabled? && ai_binding?
+    status 404
+    next({ 'error' => 'disabled' }.to_json)
   end
+  model = params['model'] || CHAT_MODELS[:primary]
+  out = Cloudflare::AI.run(
+    model,
+    { messages: [
+      { role: 'system', content: 'reply with a short Japanese greeting' },
+      { role: 'user',   content: 'こんにちは' }
+    ], max_tokens: 64 },
+    binding: ai_binding
+  )
+  {
+    'model'    => model,
+    'class'    => out.class.to_s,
+    'is_hash'  => out.is_a?(Hash),
+    'keys'     => out.is_a?(Hash) ? out.keys : nil,
+    'extracted'=> App.extract_ai_text(out),
+    'raw'      => out
+  }.to_json
+end

--- a/app/routes/fragments/route_038.rb
+++ b/app/routes/fragments/route_038.rb
@@ -1,58 +1,58 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 38 — test /test/ai
-  get '/test/ai' do
-    content_type 'application/json'
-    unless ai_demos_enabled?
-      status 404
-      next({ 'error' => 'AI demos disabled (set HOMURABI_ENABLE_AI_DEMOS=1)' }.to_json)
-    end
-    unless ai_binding?
-      status 503
-      next({ 'error' => 'AI binding not bound (wrangler.toml [ai] block missing)' }.to_json)
-    end
-
-    cases = []
-    primary  = CHAT_MODELS[:primary]
-    fallback = CHAT_MODELS[:fallback]
-
-    # NOTE: blocks-with-`__await__` compile to async functions in Opal
-    # under `# await: true`. Iterators like `Array#each_with_index`
-    # don't await each step, so any work the block kicks off races
-    # against the JSON serialisation below — the route would return
-    # `{cases: []}` before the AI call even finished. Inline a manual
-    # loop where each step is followed by an explicit `__await__`.
-
-    test_one = lambda { |model, label|
-      result = begin
-        out = Cloudflare::AI.run(model,
-          { messages: [
-            { role: 'system', content: 'reply with the single word READY' },
-            { role: 'user',   content: 'ping' }
-          ], max_tokens: 64 },
-          binding: ai_binding
-        )
-        txt = App.extract_ai_text(out).strip
-        if txt.empty?
-          { 'pass' => false, 'note' => 'empty response from model' }
-        else
-          { 'pass' => true, 'note' => txt[0, 200] }
-        end
-      rescue ::Exception => e
-        { 'pass' => false, 'note' => "#{e.class}: #{e.message[0, 200]}" }
-      end
-      result.merge('case' => label)
-    }
-
-    cases << test_one.call(primary,  "primary model #{primary} responds")
-    cases << test_one.call(fallback, "fallback model #{fallback} responds")
-
-    passed = cases.count { |c| c['pass'] }
-    failed = cases.size - passed
-    {
-      'passed' => passed,
-      'failed' => failed,
-      'total'  => cases.size,
-      'cases'  => cases
-    }.to_json
+get '/test/ai' do
+  content_type 'application/json'
+  unless ai_demos_enabled?
+    status 404
+    next({ 'error' => 'AI demos disabled (set HOMURABI_ENABLE_AI_DEMOS=1)' }.to_json)
   end
+  unless ai_binding?
+    status 503
+    next({ 'error' => 'AI binding not bound (wrangler.toml [ai] block missing)' }.to_json)
+  end
+
+  cases = []
+  primary  = CHAT_MODELS[:primary]
+  fallback = CHAT_MODELS[:fallback]
+
+  # NOTE: blocks-with-`__await__` compile to async functions in Opal
+  # under `# await: true`. Iterators like `Array#each_with_index`
+  # don't await each step, so any work the block kicks off races
+  # against the JSON serialisation below — the route would return
+  # `{cases: []}` before the AI call even finished. Inline a manual
+  # loop where each step is followed by an explicit `__await__`.
+
+  test_one = lambda { |model, label|
+    result = begin
+      out = Cloudflare::AI.run(model,
+        { messages: [
+          { role: 'system', content: 'reply with the single word READY' },
+          { role: 'user',   content: 'ping' }
+        ], max_tokens: 64 },
+        binding: ai_binding
+      )
+      txt = App.extract_ai_text(out).strip
+      if txt.empty?
+        { 'pass' => false, 'note' => 'empty response from model' }
+      else
+        { 'pass' => true, 'note' => txt[0, 200] }
+      end
+    rescue ::Exception => e
+      { 'pass' => false, 'note' => "#{e.class}: #{e.message[0, 200]}" }
+    end
+    result.merge('case' => label)
+  }
+
+  cases << test_one.call(primary,  "primary model #{primary} responds")
+  cases << test_one.call(fallback, "fallback model #{fallback} responds")
+
+  passed = cases.count { |c| c['pass'] }
+  failed = cases.size - passed
+  {
+    'passed' => passed,
+    'failed' => failed,
+    'total'  => cases.size,
+    'cases'  => cases
+  }.to_json
+end

--- a/app/routes/fragments/route_039.rb
+++ b/app/routes/fragments/route_039.rb
@@ -1,46 +1,46 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 39 — demo /demo/do/ws
-  get '/demo/do/ws' do
-    unless binding_demos_enabled?
-      status 404
-      content_type 'application/json'
-      next({ 'error' => 'binding demos disabled' }.to_json)
-    end
-    # Copilot review PR #9 (third pass): Workers only accepts a
-    # `Response` with a `.webSocket` property from a handler that
-    # was invoked by a real WebSocket-upgrade request. If a plain
-    # `curl` (no Upgrade header) hits this route, forwarding to the
-    # DO stub causes the runtime to throw ("Response with webSocket
-    # requires a WebSocket request"), surfacing as a confusing 500.
-    # Reject non-upgrade requests up-front with a 426 so clients
-    # get an intentional, documented response.
-    upgrade = (request.env['HTTP_UPGRADE'] || '').to_s.downcase
-    unless upgrade == 'websocket'
-      status 426
-      content_type 'application/json'
-      next({
-        'error' => 'Upgrade Required',
-        'detail' => 'GET /demo/do/ws must be called with `Upgrade: websocket`; use a WebSocket client.'
-      }.to_json)
-    end
-    ns = do_counter
-    if ns.nil?
-      status 503
-      content_type 'application/json'
-      next({ 'error' => 'COUNTER binding not bound' }.to_json)
-    end
-    name = (params['name'] || 'ws-demo').to_s
-    stub = ns.get_by_name(name)
-    # Forward a WebSocket-upgrade request to the DO stub. The stub's
-    # fetch() returns a 101 Response with `.webSocket` attached;
-    # Cloudflare::RawResponse signals to build_js_response that the
-    # JS Response must be passed through untouched (normal bodies
-    # lose the WebSocket property when reconstructed).
-    js_resp = stub.fetch_raw(
-      "https://homurabi-do.internal/ws/#{name}",
-      method: 'GET',
-      headers: { 'upgrade' => 'websocket' }
-    )
-    Cloudflare::RawResponse.new(js_resp)
+get '/demo/do/ws' do
+  unless binding_demos_enabled?
+    status 404
+    content_type 'application/json'
+    next({ 'error' => 'binding demos disabled' }.to_json)
   end
+  # Copilot review PR #9 (third pass): Workers only accepts a
+  # `Response` with a `.webSocket` property from a handler that
+  # was invoked by a real WebSocket-upgrade request. If a plain
+  # `curl` (no Upgrade header) hits this route, forwarding to the
+  # DO stub causes the runtime to throw ("Response with webSocket
+  # requires a WebSocket request"), surfacing as a confusing 500.
+  # Reject non-upgrade requests up-front with a 426 so clients
+  # get an intentional, documented response.
+  upgrade = (request.env['HTTP_UPGRADE'] || '').to_s.downcase
+  unless upgrade == 'websocket'
+    status 426
+    content_type 'application/json'
+    next({
+      'error' => 'Upgrade Required',
+      'detail' => 'GET /demo/do/ws must be called with `Upgrade: websocket`; use a WebSocket client.'
+    }.to_json)
+  end
+  ns = do_counter
+  if ns.nil?
+    status 503
+    content_type 'application/json'
+    next({ 'error' => 'COUNTER binding not bound' }.to_json)
+  end
+  name = (params['name'] || 'ws-demo').to_s
+  stub = ns.get_by_name(name)
+  # Forward a WebSocket-upgrade request to the DO stub. The stub's
+  # fetch() returns a 101 Response with `.webSocket` attached;
+  # Cloudflare::RawResponse signals to build_js_response that the
+  # JS Response must be passed through untouched (normal bodies
+  # lose the WebSocket property when reconstructed).
+  js_resp = stub.fetch_raw(
+    "https://homurabi-do.internal/ws/#{name}",
+    method: 'GET',
+    headers: { 'upgrade' => 'websocket' }
+  )
+  Cloudflare::RawResponse.new(js_resp)
+end

--- a/app/routes/fragments/route_040.rb
+++ b/app/routes/fragments/route_040.rb
@@ -1,32 +1,32 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 40 — demo /demo/do
-  get '/demo/do' do
-    content_type 'application/json'
-    unless binding_demos_enabled?
-      status 404
-      next({ 'error' => 'binding demos disabled (set HOMURABI_ENABLE_BINDING_DEMOS=1)' }.to_json)
-    end
-    ns = do_counter
-    if ns.nil?
-      status 503
-      next({ 'error' => 'DurableObject binding COUNTER not bound (wrangler.toml missing [[durable_objects.bindings]])' }.to_json)
-    end
-    name = (params['name'] || 'global').to_s
-    action = (params['action'] || 'inc').to_s
-    stub = ns.get_by_name(name)
-    # `stub.fetch` requires an absolute URL — the Workers runtime
-    # parses the URL to route the call. The host is irrelevant (the
-    # DO receives the whole Request), but it must be parseable.
-    url = "https://homurabi-do.internal/#{action}"
-    res = stub.fetch(url, method: 'POST')
-    {
-      'demo'    => 'Durable Objects counter',
-      'binding' => 'COUNTER',
-      'class'   => 'HomurabiCounterDO',
-      'name'    => name,
-      'action'  => action,
-      'status'  => res.status,
-      'body'    => res.body.empty? ? nil : JSON.parse(res.body)
-    }.to_json
+get '/demo/do' do
+  content_type 'application/json'
+  unless binding_demos_enabled?
+    status 404
+    next({ 'error' => 'binding demos disabled (set HOMURABI_ENABLE_BINDING_DEMOS=1)' }.to_json)
   end
+  ns = do_counter
+  if ns.nil?
+    status 503
+    next({ 'error' => 'DurableObject binding COUNTER not bound (wrangler.toml missing [[durable_objects.bindings]])' }.to_json)
+  end
+  name = (params['name'] || 'global').to_s
+  action = (params['action'] || 'inc').to_s
+  stub = ns.get_by_name(name)
+  # `stub.fetch` requires an absolute URL — the Workers runtime
+  # parses the URL to route the call. The host is irrelevant (the
+  # DO receives the whole Request), but it must be parseable.
+  url = "https://homurabi-do.internal/#{action}"
+  res = stub.fetch(url, method: 'POST')
+  {
+    'demo'    => 'Durable Objects counter',
+    'binding' => 'COUNTER',
+    'class'   => 'HomurabiCounterDO',
+    'name'    => name,
+    'action'  => action,
+    'status'  => res.status,
+    'body'    => res.body.empty? ? nil : JSON.parse(res.body)
+  }.to_json
+end

--- a/app/routes/fragments/route_041.rb
+++ b/app/routes/fragments/route_041.rb
@@ -1,50 +1,50 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 41 — demo /demo/cache/heavy
-  get '/demo/cache/heavy' do
-    content_type 'application/json'
-    unless binding_demos_enabled?
-      status 404
-      next({ 'error' => 'binding demos disabled (set HOMURABI_ENABLE_BINDING_DEMOS=1)' }.to_json)
-    end
-    # Cache by request URL so different query strings produce different
-    # cache entries (cache-busting with ?v=N works).
-    cache_key = request.url
-    ttl = (params['ttl'] || '60').to_i
-    started = Time.now.to_f
-    # cache_get uses `__await__` internally (cache.match / cache.put)
-    # so the helper method is compiled as async by Opal — its return
-    # value is a Promise we MUST `__await__` at the call site.
-    body = cache_get(cache_key, ttl: ttl) do
-      # Expensive work: derive a PBKDF2 key + hash many times so the
-      # first-request latency is non-trivial. The exact ~1000 iterations
-      # is a compromise between "clearly slower than a cache hit" and
-      # "finishes inside wrangler dev's request budget on an M1".
-      salt = SecureRandom.random_bytes(16)
-      derived = OpenSSL::KDF.pbkdf2_hmac('homurabi-phase11b',
-        salt: salt, iterations: 50_000, length: 32, hash: 'SHA256')
-      {
-        'computed'    => 'expensive PBKDF2 derivation',
-        'iterations'  => 50_000,
-        'derived_hex' => derived.unpack1('H*'),
-        'salt_hex'    => salt.unpack1('H*'),
-        'computed_at' => Time.now.to_i
-      }.to_json
-    end.__await__
-    elapsed_ms = ((Time.now.to_f - started) * 1000).round
-    # The helper set response.headers['x-homurabi-cache'] to HIT / MISS.
-    cache_state = response['X-Homurabi-Cache'] || 'UNKNOWN'
-    # Re-serialise with extra diagnostic fields so the route caller can
-    # see which path ran without cracking open headers from a browser.
-    orig = begin
-      JSON.parse(body)
-    rescue JSON::ParserError
-      { 'raw' => body }
-    end
-    orig.merge(
-      'cache'      => cache_state,
-      'elapsed_ms' => elapsed_ms,
-      'cache_key'  => cache_key,
-      'ttl'        => ttl
-    ).to_json
+get '/demo/cache/heavy' do
+  content_type 'application/json'
+  unless binding_demos_enabled?
+    status 404
+    next({ 'error' => 'binding demos disabled (set HOMURABI_ENABLE_BINDING_DEMOS=1)' }.to_json)
   end
+  # Cache by request URL so different query strings produce different
+  # cache entries (cache-busting with ?v=N works).
+  cache_key = request.url
+  ttl = (params['ttl'] || '60').to_i
+  started = Time.now.to_f
+  # cache_get uses `__await__` internally (cache.match / cache.put)
+  # so the helper method is compiled as async by Opal — its return
+  # value is a Promise we MUST `__await__` at the call site.
+  body = cache_get(cache_key, ttl: ttl) do
+    # Expensive work: derive a PBKDF2 key + hash many times so the
+    # first-request latency is non-trivial. The exact ~1000 iterations
+    # is a compromise between "clearly slower than a cache hit" and
+    # "finishes inside wrangler dev's request budget on an M1".
+    salt = SecureRandom.random_bytes(16)
+    derived = OpenSSL::KDF.pbkdf2_hmac('homurabi-phase11b',
+      salt: salt, iterations: 50_000, length: 32, hash: 'SHA256')
+    {
+      'computed'    => 'expensive PBKDF2 derivation',
+      'iterations'  => 50_000,
+      'derived_hex' => derived.unpack1('H*'),
+      'salt_hex'    => salt.unpack1('H*'),
+      'computed_at' => Time.now.to_i
+    }.to_json
+  end.__await__
+  elapsed_ms = ((Time.now.to_f - started) * 1000).round
+  # The helper set response.headers['x-homurabi-cache'] to HIT / MISS.
+  cache_state = response['X-Homurabi-Cache'] || 'UNKNOWN'
+  # Re-serialise with extra diagnostic fields so the route caller can
+  # see which path ran without cracking open headers from a browser.
+  orig = begin
+    JSON.parse(body)
+  rescue JSON::ParserError
+    { 'raw' => body }
+  end
+  orig.merge(
+    'cache'      => cache_state,
+    'elapsed_ms' => elapsed_ms,
+    'cache_key'  => cache_key,
+    'ttl'        => ttl
+  ).to_json
+end

--- a/app/routes/fragments/route_042.rb
+++ b/app/routes/fragments/route_042.rb
@@ -1,23 +1,23 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 42 — api /api/enqueue
-  post '/api/enqueue' do
-    content_type 'application/json'
-    unless binding_demos_enabled?
-      status 404
-      next({ 'error' => 'binding demos disabled (set HOMURABI_ENABLE_BINDING_DEMOS=1)' }.to_json)
-    end
-    q = jobs_queue
-    if q.nil?
-      status 503
-      next({ 'error' => 'Queue binding JOBS_QUEUE not bound (wrangler.toml missing [[queues.producers]])' }.to_json)
-    end
-    begin
-      body = JSON.parse(request.body.read)
-    rescue JSON::ParserError, StandardError
-      body = { 'note' => 'default payload (empty or invalid JSON body)', 'ts' => Time.now.to_i }
-    end
-    q.send(body)
-    status 202
-    { 'enqueued' => true, 'queue' => 'homurabi-jobs', 'payload' => body }.to_json
+post '/api/enqueue' do
+  content_type 'application/json'
+  unless binding_demos_enabled?
+    status 404
+    next({ 'error' => 'binding demos disabled (set HOMURABI_ENABLE_BINDING_DEMOS=1)' }.to_json)
   end
+  q = jobs_queue
+  if q.nil?
+    status 503
+    next({ 'error' => 'Queue binding JOBS_QUEUE not bound (wrangler.toml missing [[queues.producers]])' }.to_json)
+  end
+  begin
+    body = JSON.parse(request.body.read)
+  rescue JSON::ParserError, StandardError
+    body = { 'note' => 'default payload (empty or invalid JSON body)', 'ts' => Time.now.to_i }
+  end
+  q.send(body)
+  status 202
+  { 'enqueued' => true, 'queue' => 'homurabi-jobs', 'payload' => body }.to_json
+end

--- a/app/routes/fragments/route_043.rb
+++ b/app/routes/fragments/route_043.rb
@@ -1,32 +1,32 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 43 — demo /demo/queue/status
-  get '/demo/queue/status' do
-    content_type 'application/json'
-    unless binding_demos_enabled?
-      status 404
-      next({ 'error' => 'binding demos disabled (set HOMURABI_ENABLE_BINDING_DEMOS=1)' }.to_json)
-    end
-    if kv.nil?
-      status 503
-      next({ 'error' => 'KV not bound — cannot read consumer state' }.to_json)
-    end
-    limit = (params['limit'] || '10').to_i
-    recent = []
-    i = 0
-    while i < limit
-      raw = kv.get("queue:last-consumed:#{i}").__await__
-      break if raw.nil? || raw.empty?
-      begin
-        recent << JSON.parse(raw)
-      rescue JSON::ParserError
-        recent << { 'raw' => raw }
-      end
-      i += 1
-    end
-    {
-      'queue'   => 'homurabi-jobs',
-      'count'   => recent.size,
-      'recent'  => recent
-    }.to_json
+get '/demo/queue/status' do
+  content_type 'application/json'
+  unless binding_demos_enabled?
+    status 404
+    next({ 'error' => 'binding demos disabled (set HOMURABI_ENABLE_BINDING_DEMOS=1)' }.to_json)
   end
+  if kv.nil?
+    status 503
+    next({ 'error' => 'KV not bound — cannot read consumer state' }.to_json)
+  end
+  limit = (params['limit'] || '10').to_i
+  recent = []
+  i = 0
+  while i < limit
+    raw = kv.get("queue:last-consumed:#{i}").__await__
+    break if raw.nil? || raw.empty?
+    begin
+      recent << JSON.parse(raw)
+    rescue JSON::ParserError
+      recent << { 'raw' => raw }
+    end
+    i += 1
+  end
+  {
+    'queue'   => 'homurabi-jobs',
+    'count'   => recent.size,
+    'recent'  => recent
+  }.to_json
+end

--- a/app/routes/fragments/route_044.rb
+++ b/app/routes/fragments/route_044.rb
@@ -1,63 +1,63 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 44 — demo /demo/cache/named
-  get '/demo/cache/named' do
-    content_type 'application/json'
-    unless binding_demos_enabled?
-      status 404
-      next({ 'error' => 'binding demos disabled' }.to_json)
-    end
-    namespace = (params['namespace'] || 'frag-default').to_s
-    # Copilot review PR #9 (third pass): return a stable 400 JSON
-    # response on client input validation failures instead of
-    # raising — the app has no Sinatra error handler for
-    # ArgumentError, which would otherwise surface as 500.
-    unless namespace =~ /\A[A-Za-z0-9_-]{1,32}\z/
-      status 400
-      next({ 'error' => 'namespace must match /\\A[A-Za-z0-9_-]{1,32}\\z/',
-             'got'   => namespace }.to_json)
-    end
-    key = (params['key'] || 'demo').to_s
-    unless key =~ /\A[A-Za-z0-9._\-\/]{1,128}\z/
-      status 400
-      next({ 'error' => 'key must match /\\A[A-Za-z0-9._\\-\\/]{1,128}\\z/',
-             'got'   => key }.to_json)
-    end
-    cache_key = "https://homurabi-named-cache.internal/#{namespace}/#{key}"
-    started = Time.now.to_f
-    # Open the named partition fresh per request — the JS handle is
-    # cached per-isolate internally but the Ruby wrapper is cheap.
-    named = ::Cloudflare::Cache.open(namespace)
-    cached = named.match(cache_key).__await__
-    if cached
-      state = 'HIT'
-      # Tiny pass-through of the cached body.
-      payload = JSON.parse(cached.body) rescue { 'raw' => cached.body }
-      payload.merge(
-        'cache' => state,
-        'namespace' => namespace,
-        'key' => key,
-        'elapsed_ms' => ((Time.now.to_f - started) * 1000).round
-      ).to_json
-    else
-      state = 'MISS'
-      # Compute something uniquely attributable to this namespace/key
-      # so we can assert that two namespaces with the same key don't
-      # collide.
-      payload = {
-        'namespace' => namespace,
-        'key'       => key,
-        'nonce'     => SecureRandom.hex(8),
-        'computed_at' => Time.now.to_i
-      }
-      named.put(cache_key, payload.to_json, status: 200, headers: {
-        'content-type'  => 'application/json',
-        'cache-control' => 'public, max-age=60',
-        'date'          => Time.now.httpdate
-      }).__await__
-      payload.merge(
-        'cache' => state,
-        'elapsed_ms' => ((Time.now.to_f - started) * 1000).round
-      ).to_json
-    end
+get '/demo/cache/named' do
+  content_type 'application/json'
+  unless binding_demos_enabled?
+    status 404
+    next({ 'error' => 'binding demos disabled' }.to_json)
   end
+  namespace = (params['namespace'] || 'frag-default').to_s
+  # Copilot review PR #9 (third pass): return a stable 400 JSON
+  # response on client input validation failures instead of
+  # raising — the app has no Sinatra error handler for
+  # ArgumentError, which would otherwise surface as 500.
+  unless namespace =~ /\A[A-Za-z0-9_-]{1,32}\z/
+    status 400
+    next({ 'error' => 'namespace must match /\\A[A-Za-z0-9_-]{1,32}\\z/',
+           'got'   => namespace }.to_json)
+  end
+  key = (params['key'] || 'demo').to_s
+  unless key =~ /\A[A-Za-z0-9._\-\/]{1,128}\z/
+    status 400
+    next({ 'error' => 'key must match /\\A[A-Za-z0-9._\\-\\/]{1,128}\\z/',
+           'got'   => key }.to_json)
+  end
+  cache_key = "https://homurabi-named-cache.internal/#{namespace}/#{key}"
+  started = Time.now.to_f
+  # Open the named partition fresh per request — the JS handle is
+  # cached per-isolate internally but the Ruby wrapper is cheap.
+  named = ::Cloudflare::Cache.open(namespace)
+  cached = named.match(cache_key).__await__
+  if cached
+    state = 'HIT'
+    # Tiny pass-through of the cached body.
+    payload = JSON.parse(cached.body) rescue { 'raw' => cached.body }
+    payload.merge(
+      'cache' => state,
+      'namespace' => namespace,
+      'key' => key,
+      'elapsed_ms' => ((Time.now.to_f - started) * 1000).round
+    ).to_json
+  else
+    state = 'MISS'
+    # Compute something uniquely attributable to this namespace/key
+    # so we can assert that two namespaces with the same key don't
+    # collide.
+    payload = {
+      'namespace' => namespace,
+      'key'       => key,
+      'nonce'     => SecureRandom.hex(8),
+      'computed_at' => Time.now.to_i
+    }
+    named.put(cache_key, payload.to_json, status: 200, headers: {
+      'content-type'  => 'application/json',
+      'cache-control' => 'public, max-age=60',
+      'date'          => Time.now.httpdate
+    }).__await__
+    payload.merge(
+      'cache' => state,
+      'elapsed_ms' => ((Time.now.to_f - started) * 1000).round
+    ).to_json
+  end
+end

--- a/app/routes/fragments/route_045.rb
+++ b/app/routes/fragments/route_045.rb
@@ -1,30 +1,30 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 45 — test /test/queue/fire
-  post '/test/queue/fire' do
-    content_type 'application/json'
-    unless binding_demos_enabled?
-      status 404
-      next({ 'error' => 'binding demos disabled' }.to_json)
-    end
-    body = begin
-      JSON.parse(request.body.read)
-    rescue StandardError
-      {}
-    end
-    qname = (body['queue'] || 'homurabi-jobs').to_s
-    messages = body['messages'].is_a?(Array) ? body['messages'] : [{ 'fire' => true, 'ts' => Time.now.to_i }]
-
-    js_msgs = `([])`
-    idx = 0
-    messages.each do |m|
-      js_body = Cloudflare::AI.ruby_to_js(m)
-      i_str = "manual-#{Time.now.to_i}-#{idx}"
-      now_ms = (Time.now.to_f * 1000).to_i
-      `#{js_msgs}.push({ id: #{i_str}, timestamp: new Date(#{now_ms}), body: #{js_body}, ack: function() {}, retry: function() {} })`
-      idx += 1
-    end
-    js_batch = `({ queue: #{qname}, messages: #{js_msgs}, ackAll: function() {}, retryAll: function() {} })`
-    summary = Cloudflare::QueueConsumer.dispatch_js(js_batch, env['cloudflare.env'], env['cloudflare.ctx'])
-    summary.merge('injected' => messages.size).to_json
+post '/test/queue/fire' do
+  content_type 'application/json'
+  unless binding_demos_enabled?
+    status 404
+    next({ 'error' => 'binding demos disabled' }.to_json)
   end
+  body = begin
+    JSON.parse(request.body.read)
+  rescue StandardError
+    {}
+  end
+  qname = (body['queue'] || 'homurabi-jobs').to_s
+  messages = body['messages'].is_a?(Array) ? body['messages'] : [{ 'fire' => true, 'ts' => Time.now.to_i }]
+
+  js_msgs = `([])`
+  idx = 0
+  messages.each do |m|
+    js_body = Cloudflare::AI.ruby_to_js(m)
+    i_str = "manual-#{Time.now.to_i}-#{idx}"
+    now_ms = (Time.now.to_f * 1000).to_i
+    `#{js_msgs}.push({ id: #{i_str}, timestamp: new Date(#{now_ms}), body: #{js_body}, ack: function() {}, retry: function() {} })`
+    idx += 1
+  end
+  js_batch = `({ queue: #{qname}, messages: #{js_msgs}, ackAll: function() {}, retryAll: function() {} })`
+  summary = Cloudflare::QueueConsumer.dispatch_js(js_batch, env['cloudflare.env'], env['cloudflare.ctx'])
+  summary.merge('injected' => messages.size).to_json
+end

--- a/app/routes/fragments/route_046.rb
+++ b/app/routes/fragments/route_046.rb
@@ -1,32 +1,32 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 46 — demo /demo/queue/dlq-status
-  get '/demo/queue/dlq-status' do
-    content_type 'application/json'
-    unless binding_demos_enabled?
-      status 404
-      next({ 'error' => 'binding demos disabled' }.to_json)
-    end
-    if kv.nil?
-      status 503
-      next({ 'error' => 'KV not bound — cannot read DLQ state' }.to_json)
-    end
-    limit = (params['limit'] || '10').to_i
-    recent = []
-    i = 0
-    while i < limit
-      raw = kv.get("queue:dlq:#{i}").__await__
-      break if raw.nil? || raw.empty?
-      begin
-        recent << JSON.parse(raw)
-      rescue JSON::ParserError
-        recent << { 'raw' => raw }
-      end
-      i += 1
-    end
-    {
-      'queue'   => 'homurabi-jobs-dlq',
-      'count'   => recent.size,
-      'recent'  => recent
-    }.to_json
+get '/demo/queue/dlq-status' do
+  content_type 'application/json'
+  unless binding_demos_enabled?
+    status 404
+    next({ 'error' => 'binding demos disabled' }.to_json)
   end
+  if kv.nil?
+    status 503
+    next({ 'error' => 'KV not bound — cannot read DLQ state' }.to_json)
+  end
+  limit = (params['limit'] || '10').to_i
+  recent = []
+  i = 0
+  while i < limit
+    raw = kv.get("queue:dlq:#{i}").__await__
+    break if raw.nil? || raw.empty?
+    begin
+      recent << JSON.parse(raw)
+    rescue JSON::ParserError
+      recent << { 'raw' => raw }
+    end
+    i += 1
+  end
+  {
+    'queue'   => 'homurabi-jobs-dlq',
+    'count'   => recent.size,
+    'recent'  => recent
+  }.to_json
+end

--- a/app/routes/fragments/route_047.rb
+++ b/app/routes/fragments/route_047.rb
@@ -1,19 +1,19 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 47 — demo /demo/queue/force-dlq
-  post '/demo/queue/force-dlq' do
-    content_type 'application/json'
-    unless binding_demos_enabled?
-      status 404
-      next({ 'error' => 'binding demos disabled' }.to_json)
-    end
-    q = jobs_queue
-    if q.nil?
-      status 503
-      next({ 'error' => 'Queue binding JOBS_QUEUE not bound' }.to_json)
-    end
-    payload = { 'fail' => true, 'reason' => 'force-dlq demo', 'ts' => Time.now.to_i }
-    q.send(payload)
-    status 202
-    { 'enqueued' => true, 'payload' => payload, 'note' => 'main consumer will retry up to max_retries; then the runtime forwards the message to homurabi-jobs-dlq' }.to_json
+post '/demo/queue/force-dlq' do
+  content_type 'application/json'
+  unless binding_demos_enabled?
+    status 404
+    next({ 'error' => 'binding demos disabled' }.to_json)
   end
+  q = jobs_queue
+  if q.nil?
+    status 503
+    next({ 'error' => 'Queue binding JOBS_QUEUE not bound' }.to_json)
+  end
+  payload = { 'fail' => true, 'reason' => 'force-dlq demo', 'ts' => Time.now.to_i }
+  q.send(payload)
+  status 202
+  { 'enqueued' => true, 'payload' => payload, 'note' => 'main consumer will retry up to max_retries; then the runtime forwards the message to homurabi-jobs-dlq' }.to_json
+end

--- a/app/routes/fragments/route_048.rb
+++ b/app/routes/fragments/route_048.rb
@@ -1,94 +1,94 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 48 — test /test/bindings
-  get '/test/bindings' do
-    content_type 'application/json'
-    unless binding_demos_enabled?
-      status 404
-      next({ 'error' => 'binding demos disabled (set HOMURABI_ENABLE_BINDING_DEMOS=1)' }.to_json)
-    end
-    cases = []
-    started = Time.now.to_f
-
-    # 1. DurableObject round-trip
-    do_case = { 'case' => 'DurableObject counter inc/peek/reset round-trip' }
-    begin
-      ns = do_counter
-      if ns.nil?
-        do_case['pass'] = false
-        do_case['note'] = 'COUNTER binding not bound'
-      else
-        name = "selftest-#{SecureRandom.hex(4)}"
-        stub = ns.get_by_name(name)
-        base = 'https://homurabi-do.internal'
-        stub.fetch("#{base}/reset", method: 'POST')
-        r1 = JSON.parse(stub.fetch("#{base}/inc", method: 'POST').body)
-        r2 = JSON.parse(stub.fetch("#{base}/inc", method: 'POST').body)
-        peek = JSON.parse(stub.fetch("#{base}/peek").body)
-        do_case['pass'] = r1['count'] == 1 && r2['count'] == 2 && peek['count'] == 2
-        do_case['detail'] = { 'r1' => r1, 'r2' => r2, 'peek' => peek }
-        stub.fetch("#{base}/reset", method: 'POST')
-      end
-    rescue ::Exception => e
-      do_case['pass'] = false
-      do_case['note'] = "#{e.class}: #{e.message[0, 200]}"
-    end
-    cases << do_case
-
-    # 2. Cache API put/match round-trip
-    cache_case = { 'case' => 'Cache API match after put returns same body' }
-    begin
-      c = cache
-      key = "https://cache-selftest.example/phase11b-#{SecureRandom.hex(4)}"
-      payload = { 'self_test' => true, 'ts' => Time.now.to_i }.to_json
-      c.put(key, payload, status: 200, headers: {
-        'content-type'  => 'application/json',
-        'cache-control' => 'public, max-age=30',
-        'date'          => Time.now.httpdate
-      }).__await__
-      got = c.match(key).__await__
-      if got.nil?
-        cache_case['pass'] = false
-        cache_case['note'] = 'match returned nil after put (cache unavailable in this runtime?)'
-      else
-        cache_case['pass'] = got.body == payload
-        cache_case['detail'] = { 'status' => got.status, 'content_type' => got['content-type'] }
-      end
-    rescue ::Exception => e
-      cache_case['pass'] = false
-      cache_case['note'] = "#{e.class}: #{e.message[0, 200]}"
-    end
-    cases << cache_case
-
-    # 3. Queue producer .send succeeds (does not crash). We can't
-    # synchronously assert delivery because the consumer runs in a
-    # separate invocation; instead we check that the producer returned
-    # without error and, when KV is available, that at least one
-    # message had been delivered previously (warmup from /api/enqueue).
-    queue_case = { 'case' => 'Queue producer send() returns without error' }
-    begin
-      q = jobs_queue
-      if q.nil?
-        queue_case['pass'] = false
-        queue_case['note'] = 'JOBS_QUEUE binding not bound'
-      else
-        q.send({ 'selftest' => true, 'ts' => Time.now.to_i, 'nonce' => SecureRandom.hex(4) })
-        queue_case['pass'] = true
-        queue_case['note'] = 'producer.send completed'
-      end
-    rescue ::Exception => e
-      queue_case['pass'] = false
-      queue_case['note'] = "#{e.class}: #{e.message[0, 200]}"
-    end
-    cases << queue_case
-
-    passed = cases.count { |c| c['pass'] }
-    failed = cases.size - passed
-    {
-      'passed'    => passed,
-      'failed'    => failed,
-      'total'     => cases.size,
-      'elapsed_ms'=> ((Time.now.to_f - started) * 1000).round,
-      'cases'     => cases
-    }.to_json
+get '/test/bindings' do
+  content_type 'application/json'
+  unless binding_demos_enabled?
+    status 404
+    next({ 'error' => 'binding demos disabled (set HOMURABI_ENABLE_BINDING_DEMOS=1)' }.to_json)
   end
+  cases = []
+  started = Time.now.to_f
+
+  # 1. DurableObject round-trip
+  do_case = { 'case' => 'DurableObject counter inc/peek/reset round-trip' }
+  begin
+    ns = do_counter
+    if ns.nil?
+      do_case['pass'] = false
+      do_case['note'] = 'COUNTER binding not bound'
+    else
+      name = "selftest-#{SecureRandom.hex(4)}"
+      stub = ns.get_by_name(name)
+      base = 'https://homurabi-do.internal'
+      stub.fetch("#{base}/reset", method: 'POST')
+      r1 = JSON.parse(stub.fetch("#{base}/inc", method: 'POST').body)
+      r2 = JSON.parse(stub.fetch("#{base}/inc", method: 'POST').body)
+      peek = JSON.parse(stub.fetch("#{base}/peek").body)
+      do_case['pass'] = r1['count'] == 1 && r2['count'] == 2 && peek['count'] == 2
+      do_case['detail'] = { 'r1' => r1, 'r2' => r2, 'peek' => peek }
+      stub.fetch("#{base}/reset", method: 'POST')
+    end
+  rescue ::Exception => e
+    do_case['pass'] = false
+    do_case['note'] = "#{e.class}: #{e.message[0, 200]}"
+  end
+  cases << do_case
+
+  # 2. Cache API put/match round-trip
+  cache_case = { 'case' => 'Cache API match after put returns same body' }
+  begin
+    c = cache
+    key = "https://cache-selftest.example/phase11b-#{SecureRandom.hex(4)}"
+    payload = { 'self_test' => true, 'ts' => Time.now.to_i }.to_json
+    c.put(key, payload, status: 200, headers: {
+      'content-type'  => 'application/json',
+      'cache-control' => 'public, max-age=30',
+      'date'          => Time.now.httpdate
+    }).__await__
+    got = c.match(key).__await__
+    if got.nil?
+      cache_case['pass'] = false
+      cache_case['note'] = 'match returned nil after put (cache unavailable in this runtime?)'
+    else
+      cache_case['pass'] = got.body == payload
+      cache_case['detail'] = { 'status' => got.status, 'content_type' => got['content-type'] }
+    end
+  rescue ::Exception => e
+    cache_case['pass'] = false
+    cache_case['note'] = "#{e.class}: #{e.message[0, 200]}"
+  end
+  cases << cache_case
+
+  # 3. Queue producer .send succeeds (does not crash). We can't
+  # synchronously assert delivery because the consumer runs in a
+  # separate invocation; instead we check that the producer returned
+  # without error and, when KV is available, that at least one
+  # message had been delivered previously (warmup from /api/enqueue).
+  queue_case = { 'case' => 'Queue producer send() returns without error' }
+  begin
+    q = jobs_queue
+    if q.nil?
+      queue_case['pass'] = false
+      queue_case['note'] = 'JOBS_QUEUE binding not bound'
+    else
+      q.send({ 'selftest' => true, 'ts' => Time.now.to_i, 'nonce' => SecureRandom.hex(4) })
+      queue_case['pass'] = true
+      queue_case['note'] = 'producer.send completed'
+    end
+  rescue ::Exception => e
+    queue_case['pass'] = false
+    queue_case['note'] = "#{e.class}: #{e.message[0, 200]}"
+  end
+  cases << queue_case
+
+  passed = cases.count { |c| c['pass'] }
+  failed = cases.size - passed
+  {
+    'passed'    => passed,
+    'failed'    => failed,
+    'total'     => cases.size,
+    'elapsed_ms'=> ((Time.now.to_f - started) * 1000).round,
+    'cases'     => cases
+  }.to_json
+end

--- a/app/routes/fragments/route_049.rb
+++ b/app/routes/fragments/route_049.rb
@@ -1,24 +1,24 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 49 — demo /demo/faraday
-  get '/demo/faraday' do
-    content_type 'application/json'
-    unless foundations_demos_enabled?
-      status 404
-      next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
-    end
-    client = Faraday.new(url: 'https://api.ipify.org') do |c|
-      c.request :json
-      c.response :json
-      c.headers['user-agent'] = 'homurabi-phase11a/1.0'
-    end
-    res = client.get('/', { 'format' => 'json' }).__await__
-    {
-      'demo'        => 'Faraday.new(url:) { request :json; response :json }',
-      'status'      => res.status,
-      'success'     => res.success?,
-      'reason'      => res.reason_phrase,
-      'body'        => res.body,  # parsed Hash thanks to :json middleware
-      'headers_ct'  => res.headers['content-type']
-    }.to_json
+get '/demo/faraday' do
+  content_type 'application/json'
+  unless foundations_demos_enabled?
+    status 404
+    next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
   end
+  client = Faraday.new(url: 'https://api.ipify.org') do |c|
+    c.request :json
+    c.response :json
+    c.headers['user-agent'] = 'homurabi-phase11a/1.0'
+  end
+  res = client.get('/', { 'format' => 'json' }).__await__
+  {
+    'demo'        => 'Faraday.new(url:) { request :json; response :json }',
+    'status'      => res.status,
+    'success'     => res.success?,
+    'reason'      => res.reason_phrase,
+    'body'        => res.body,  # parsed Hash thanks to :json middleware
+    'headers_ct'  => res.headers['content-type']
+  }.to_json
+end

--- a/app/routes/fragments/route_050.rb
+++ b/app/routes/fragments/route_050.rb
@@ -1,54 +1,54 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 50 — api /api/upload
-  post '/api/upload' do
-    content_type 'application/json'
-    unless foundations_demos_enabled?
-      status 404
-      next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
-    end
-    # pull params BEFORE the first await — Sinatra clears @params when
-    # it starts a Promise-returning route (same ceremony as /d1/users).
-    file_param = params['file']
-    note_param = params['note'].to_s
-    unless file_param.is_a?(::Cloudflare::UploadedFile)
-      status 400
-      next({ 'error' => 'missing "file" multipart part' }.to_json)
-    end
-
-    # Only accept images — this is the /phase11a/upload demo's purpose.
-    # Rejecting non-image content types here stops the gallery ever
-    # accumulating bytes it can't render (the historical curl-smoke
-    # `.bin` payloads came in before this check existed).
-    ct = file_param.content_type.to_s
-    unless ct.start_with?('image/')
-      status 415  # Unsupported Media Type
-      next({
-        'error'         => 'only image/* content types are accepted',
-        'received_type' => ct.empty? ? '(missing)' : ct,
-        'filename'      => file_param.filename
-      }.to_json)
-    end
-
-    if bucket.nil?
-      status 503
-      next({ 'error' => 'R2 binding not configured' }.to_json)
-    end
-
-    # Pick a random key under a phase11a/ prefix so we don't collide
-    # with the existing /r2/:key demos.
-    key = "phase11a/uploads/#{SecureRandom.hex(8)}-#{file_param.filename}"
-    u8  = file_param.to_uint8_array
-    bucket.put(key, u8, file_param.content_type).__await__
-
-    status 201
-    {
-      'stored'       => true,
-      'key'          => key,
-      'filename'     => file_param.filename,
-      'content_type' => file_param.content_type,
-      'size'         => file_param.size,
-      'note'         => note_param,
-      'url'          => "/r2/#{key}"  # hit via GET /images/:key for binary
-    }.to_json
+post '/api/upload' do
+  content_type 'application/json'
+  unless foundations_demos_enabled?
+    status 404
+    next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
   end
+  # pull params BEFORE the first await — Sinatra clears @params when
+  # it starts a Promise-returning route (same ceremony as /d1/users).
+  file_param = params['file']
+  note_param = params['note'].to_s
+  unless file_param.is_a?(::Cloudflare::UploadedFile)
+    status 400
+    next({ 'error' => 'missing "file" multipart part' }.to_json)
+  end
+
+  # Only accept images — this is the /phase11a/upload demo's purpose.
+  # Rejecting non-image content types here stops the gallery ever
+  # accumulating bytes it can't render (the historical curl-smoke
+  # `.bin` payloads came in before this check existed).
+  ct = file_param.content_type.to_s
+  unless ct.start_with?('image/')
+    status 415  # Unsupported Media Type
+    next({
+      'error'         => 'only image/* content types are accepted',
+      'received_type' => ct.empty? ? '(missing)' : ct,
+      'filename'      => file_param.filename
+    }.to_json)
+  end
+
+  if bucket.nil?
+    status 503
+    next({ 'error' => 'R2 binding not configured' }.to_json)
+  end
+
+  # Pick a random key under a phase11a/ prefix so we don't collide
+  # with the existing /r2/:key demos.
+  key = "phase11a/uploads/#{SecureRandom.hex(8)}-#{file_param.filename}"
+  u8  = file_param.to_uint8_array
+  bucket.put(key, u8, file_param.content_type).__await__
+
+  status 201
+  {
+    'stored'       => true,
+    'key'          => key,
+    'filename'     => file_param.filename,
+    'content_type' => file_param.content_type,
+    'size'         => file_param.size,
+    'note'         => note_param,
+    'url'          => "/r2/#{key}"  # hit via GET /images/:key for binary
+  }.to_json
+end

--- a/app/routes/fragments/route_051.rb
+++ b/app/routes/fragments/route_051.rb
@@ -1,40 +1,40 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 51 — demo /phase11a/upload
-  get '/phase11a/upload' do
-    @title = 'Phase 11A — image upload demo'
-    unless foundations_demos_enabled?
-      status 404
-      @content = '<p>foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1).</p>'
-      next erb :layout
-    end
-    @images = []
-    @non_image_count = 0
-    if bucket
-      rows = bucket.list(prefix: 'phase11a/uploads/', limit: 50)
-      # Partition into image rows (→ gallery) and non-image rows
-      # (legacy curl-smoke binary payloads that predate the MIME
-      # guard below). The gallery only renders real images so we
-      # never draw an `<img src=…>` pointing at bytes the browser
-      # can't decode.
-      rows.each do |row|
-        ct = row['content_type'].to_s
-        if ct.start_with?('image/')
-          filename = row['key'].to_s.split('/').last.to_s
-          display_name = filename.sub(/\A[0-9a-f]+-/, '')
-          @images << {
-            'key'          => row['key'],
-            'download_url' => "/phase11a/download/#{row['key']}",
-            'filename'     => display_name,
-            'content_type' => ct,
-            'size'         => row['size'],
-            'note'         => nil  # R2 doesn't preserve our custom note
-          }
-        else
-          @non_image_count += 1
-        end
+get '/phase11a/upload' do
+  @title = 'Phase 11A — image upload demo'
+  unless foundations_demos_enabled?
+    status 404
+    @content = '<p>foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1).</p>'
+    next erb :layout
+  end
+  @images = []
+  @non_image_count = 0
+  if bucket
+    rows = bucket.list(prefix: 'phase11a/uploads/', limit: 50)
+    # Partition into image rows (→ gallery) and non-image rows
+    # (legacy curl-smoke binary payloads that predate the MIME
+    # guard below). The gallery only renders real images so we
+    # never draw an `<img src=…>` pointing at bytes the browser
+    # can't decode.
+    rows.each do |row|
+      ct = row['content_type'].to_s
+      if ct.start_with?('image/')
+        filename = row['key'].to_s.split('/').last.to_s
+        display_name = filename.sub(/\A[0-9a-f]+-/, '')
+        @images << {
+          'key'          => row['key'],
+          'download_url' => "/phase11a/download/#{row['key']}",
+          'filename'     => display_name,
+          'content_type' => ct,
+          'size'         => row['size'],
+          'note'         => nil  # R2 doesn't preserve our custom note
+        }
+      else
+        @non_image_count += 1
       end
     end
-    @content = erb :phase11a_upload
-    erb :layout
   end
+  @content = erb :phase11a_upload
+  erb :layout
+end

--- a/app/routes/fragments/route_052.rb
+++ b/app/routes/fragments/route_052.rb
@@ -1,26 +1,26 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 52 — demo /phase11a/cleanup
-  post '/phase11a/cleanup' do
-    content_type 'application/json'
-    unless foundations_demos_enabled?
-      status 404
-      next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
-    end
-    if bucket.nil?
-      status 503
-      next({ 'error' => 'R2 binding not configured' }.to_json)
-    end
-    rows = bucket.list(prefix: 'phase11a/uploads/', limit: 1000)
-    deleted_keys = []
-    rows.each do |row|
-      ct = row['content_type'].to_s
-      next if ct.start_with?('image/')
-      k = row['key'].to_s
-      # Double-check we're still in our prefix before deleting.
-      next unless k.start_with?('phase11a/uploads/')
-      bucket.delete(k).__await__
-      deleted_keys << k
-    end
-    { 'deleted_count' => deleted_keys.length, 'deleted' => deleted_keys }.to_json
+post '/phase11a/cleanup' do
+  content_type 'application/json'
+  unless foundations_demos_enabled?
+    status 404
+    next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
   end
+  if bucket.nil?
+    status 503
+    next({ 'error' => 'R2 binding not configured' }.to_json)
+  end
+  rows = bucket.list(prefix: 'phase11a/uploads/', limit: 1000)
+  deleted_keys = []
+  rows.each do |row|
+    ct = row['content_type'].to_s
+    next if ct.start_with?('image/')
+    k = row['key'].to_s
+    # Double-check we're still in our prefix before deleting.
+    next unless k.start_with?('phase11a/uploads/')
+    bucket.delete(k).__await__
+    deleted_keys << k
+  end
+  { 'deleted_count' => deleted_keys.length, 'deleted' => deleted_keys }.to_json
+end

--- a/app/routes/fragments/route_053.rb
+++ b/app/routes/fragments/route_053.rb
@@ -1,25 +1,25 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 53 — demo /phase11a/uploads/*
-  delete '/phase11a/uploads/*' do
-    content_type 'application/json'
-    unless foundations_demos_enabled?
-      status 404
-      next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
-    end
-    if bucket.nil?
-      status 503
-      next({ 'error' => 'R2 binding not configured' }.to_json)
-    end
-    key = params['splat'].is_a?(Array) ? params['splat'].join('/') : params['splat'].to_s
-    full = "phase11a/uploads/#{key}"
-    # Safety: only ever delete under our own prefix. The splat route
-    # already enforces this prefix structurally, but a belt-and-braces
-    # startswith check protects against future routing changes.
-    unless full.start_with?('phase11a/uploads/')
-      status 400
-      next({ 'error' => 'refusing to delete outside phase11a/uploads/', 'key' => full }.to_json)
-    end
-    bucket.delete(full).__await__
-    { 'deleted' => true, 'key' => full }.to_json
+delete '/phase11a/uploads/*' do
+  content_type 'application/json'
+  unless foundations_demos_enabled?
+    status 404
+    next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
   end
+  if bucket.nil?
+    status 503
+    next({ 'error' => 'R2 binding not configured' }.to_json)
+  end
+  key = params['splat'].is_a?(Array) ? params['splat'].join('/') : params['splat'].to_s
+  full = "phase11a/uploads/#{key}"
+  # Safety: only ever delete under our own prefix. The splat route
+  # already enforces this prefix structurally, but a belt-and-braces
+  # startswith check protects against future routing changes.
+  unless full.start_with?('phase11a/uploads/')
+    status 400
+    next({ 'error' => 'refusing to delete outside phase11a/uploads/', 'key' => full }.to_json)
+  end
+  bucket.delete(full).__await__
+  { 'deleted' => true, 'key' => full }.to_json
+end

--- a/app/routes/fragments/route_054.rb
+++ b/app/routes/fragments/route_054.rb
@@ -1,24 +1,24 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 54 — demo /phase11a/download/*
-  get '/phase11a/download/*' do
-    unless foundations_demos_enabled?
-      content_type 'application/json'
-      status 404
-      next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
-    end
-    if bucket.nil?
-      content_type 'application/json'
-      status 503
-      next({ 'error' => 'R2 binding not configured' }.to_json)
-    end
-    key = params['splat'].is_a?(Array) ? params['splat'].join('/') : params['splat'].to_s
-    obj = bucket.get_binary(key)
-    if obj.nil?
-      content_type 'application/json'
-      status 404
-      next({ 'error' => 'not found', 'key' => key }.to_json)
-    else
-      obj  # BinaryBody — build_js_response streams raw bytes to client
-    end
+get '/phase11a/download/*' do
+  unless foundations_demos_enabled?
+    content_type 'application/json'
+    status 404
+    next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
   end
+  if bucket.nil?
+    content_type 'application/json'
+    status 503
+    next({ 'error' => 'R2 binding not configured' }.to_json)
+  end
+  key = params['splat'].is_a?(Array) ? params['splat'].join('/') : params['splat'].to_s
+  obj = bucket.get_binary(key)
+  if obj.nil?
+    content_type 'application/json'
+    status 404
+    next({ 'error' => 'not found', 'key' => key }.to_json)
+  else
+    obj  # BinaryBody — build_js_response streams raw bytes to client
+  end
+end

--- a/app/routes/fragments/route_055.rb
+++ b/app/routes/fragments/route_055.rb
@@ -1,19 +1,19 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 55 — demo /demo/stream
-  get '/demo/stream' do
-    unless foundations_demos_enabled?
-      content_type 'application/json'
-      status 404
-      next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
-    end
-    stream do |out|
-      i = 0
-      while i < 3
-        out << "chunk #{i} @ #{Time.now.to_i}\n"
-        out.sleep(0.5)
-        i += 1
-      end
-      out << "done\n"
-    end
+get '/demo/stream' do
+  unless foundations_demos_enabled?
+    content_type 'application/json'
+    status 404
+    next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
   end
+  stream do |out|
+    i = 0
+    while i < 3
+      out << "chunk #{i} @ #{Time.now.to_i}\n"
+      out.sleep(0.5)
+      i += 1
+    end
+    out << "done\n"
+  end
+end

--- a/app/routes/fragments/route_056.rb
+++ b/app/routes/fragments/route_056.rb
@@ -1,30 +1,30 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 56 — demo /demo/sse
-  get '/demo/sse' do
-    unless foundations_demos_enabled?
-      content_type 'application/json'
-      status 404
-      next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
-    end
-    sse do |out|
-      # Manual `while` instead of `Integer#times` because Opal compiles
-      # `.each` / `.times` iterators as synchronous JS `for` loops —
-      # the async block returns a Promise per iteration that the loop
-      # does NOT await, so all five ticks would flush as a single
-      # batch (CPU ~8ms total instead of the intended ~5s). A bare
-      # `while` inside a `# await: true` block compiles to a real
-      # async JS loop that honours `await` between iterations.
-      i = 0
-      while i < 5
-        out.event(
-          { 'tick' => i, 'ts' => Time.now.to_i, 'note' => 'phase11a-sse' }.to_json,
-          event: 'heartbeat',
-          id: i.to_s
-        )
-        out.sleep(1)
-        i += 1
-      end
-      out.event('done', event: 'close')
-    end
+get '/demo/sse' do
+  unless foundations_demos_enabled?
+    content_type 'application/json'
+    status 404
+    next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
   end
+  sse do |out|
+    # Manual `while` instead of `Integer#times` because Opal compiles
+    # `.each` / `.times` iterators as synchronous JS `for` loops —
+    # the async block returns a Promise per iteration that the loop
+    # does NOT await, so all five ticks would flush as a single
+    # batch (CPU ~8ms total instead of the intended ~5s). A bare
+    # `while` inside a `# await: true` block compiles to a real
+    # async JS loop that honours `await` between iterations.
+    i = 0
+    while i < 5
+      out.event(
+        { 'tick' => i, 'ts' => Time.now.to_i, 'note' => 'phase11a-sse' }.to_json,
+        event: 'heartbeat',
+        id: i.to_s
+      )
+      out.sleep(1)
+      i += 1
+    end
+    out.event('done', event: 'close')
+  end
+end

--- a/app/routes/fragments/route_057.rb
+++ b/app/routes/fragments/route_057.rb
@@ -1,139 +1,139 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 57 — test /test/foundations
-  get '/test/foundations' do
-    content_type 'application/json'
-    unless foundations_demos_enabled?
-      status 404
-      next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
+get '/test/foundations' do
+  content_type 'application/json'
+  unless foundations_demos_enabled?
+    status 404
+    next({ 'error' => 'foundations demos disabled (set HOMURABI_ENABLE_FOUNDATIONS_DEMOS=1)' }.to_json)
+  end
+
+  cases = []
+  run = lambda { |label, &blk|
+    result = begin
+      v = blk.call
+      v == false ? { 'pass' => false, 'note' => 'returned false' } : { 'pass' => true }
+    rescue ::Exception => e
+      { 'pass' => false, 'note' => "#{e.class}: #{e.message[0, 200]}" }
     end
+    cases << result.merge('case' => label)
+  }
 
-    cases = []
-    run = lambda { |label, &blk|
-      result = begin
-        v = blk.call
-        v == false ? { 'pass' => false, 'note' => 'returned false' } : { 'pass' => true }
-      rescue ::Exception => e
-        { 'pass' => false, 'note' => "#{e.class}: #{e.message[0, 200]}" }
-      end
-      cases << result.merge('case' => label)
-    }
+  # Faraday GET with :json middleware, hitting the only stable public
+  # API we're willing to depend on in a self-test (ipify). httpbin.org
+  # was tried here earlier and blew up the Workers isolate with
+  # "Reached heap limit" — the body comes back huge and JSON-parsing
+  # it inside Opal is not free.
+  run.call('Faraday GET with :json middleware round-trips') {
+    c = Faraday.new(url: 'https://api.ipify.org') do |conn|
+      conn.request :json
+      conn.response :json
+    end
+    res = c.get('/', { 'format' => 'json' }).__await__
+    res.success? && res.body.is_a?(Hash) && res.body['ip']
+  }
 
-    # Faraday GET with :json middleware, hitting the only stable public
-    # API we're willing to depend on in a self-test (ipify). httpbin.org
-    # was tried here earlier and blew up the Workers isolate with
-    # "Reached heap limit" — the body comes back huge and JSON-parsing
-    # it inside Opal is not free.
-    run.call('Faraday GET with :json middleware round-trips') {
-      c = Faraday.new(url: 'https://api.ipify.org') do |conn|
-        conn.request :json
-        conn.response :json
-      end
-      res = c.get('/', { 'format' => 'json' }).__await__
-      res.success? && res.body.is_a?(Hash) && res.body['ip']
-    }
+  # :raise_error + Faraday.new on an existing URL that returns non-2xx.
+  # We don't hit httpbin (too heavy), so use an obviously-404 path on
+  # ipify which always responds 404 with a short body.
+  run.call('Faraday raise_error raises ResourceNotFound on 404') {
+    c = Faraday.new(url: 'https://api.ipify.org') do |conn|
+      conn.response :raise_error
+    end
+    raised = nil
+    begin
+      c.get('/this-path-does-not-exist-11a').__await__
+    rescue Faraday::ResourceNotFound => e
+      raised = e
+    end
+    raised && raised.response_status == 404
+  }
 
-    # :raise_error + Faraday.new on an existing URL that returns non-2xx.
-    # We don't hit httpbin (too heavy), so use an obviously-404 path on
-    # ipify which always responds 404 with a short body.
-    run.call('Faraday raise_error raises ResourceNotFound on 404') {
-      c = Faraday.new(url: 'https://api.ipify.org') do |conn|
-        conn.response :raise_error
-      end
-      raised = nil
-      begin
-        c.get('/this-path-does-not-exist-11a').__await__
-      rescue Faraday::ResourceNotFound => e
-        raised = e
-      end
-      raised && raised.response_status == 404
-    }
+  # Offline test — the :json request middleware must encode a Hash
+  # body as JSON without hitting the network. We inspect the Env
+  # directly instead of a live round-trip.
+  run.call('Faraday :json middleware encodes Hash body (offline)') {
+    env = Faraday::Env.new(method: :post, url: 'https://example.com/x')
+    env.body = { 'name' => 'homurabi', 'phase' => 11 }
+    Faraday::Middleware::JSON.new.on_request(env)
+    env.body == '{"name":"homurabi","phase":11}' &&
+      env.request_headers['content-type'] == 'application/json'
+  }
 
-    # Offline test — the :json request middleware must encode a Hash
-    # body as JSON without hitting the network. We inspect the Env
-    # directly instead of a live round-trip.
-    run.call('Faraday :json middleware encodes Hash body (offline)') {
-      env = Faraday::Env.new(method: :post, url: 'https://example.com/x')
-      env.body = { 'name' => 'homurabi', 'phase' => 11 }
-      Faraday::Middleware::JSON.new.on_request(env)
-      env.body == '{"name":"homurabi","phase":11}' &&
-        env.request_headers['content-type'] == 'application/json'
-    }
+  run.call('Multipart parser extracts file + text field') {
+    boundary = '----phase11atest'
+    body = ''
+    body += "--#{boundary}\r\n"
+    body += "Content-Disposition: form-data; name=\"note\"\r\n\r\n"
+    body += "hello-11a\r\n"
+    body += "--#{boundary}\r\n"
+    body += "Content-Disposition: form-data; name=\"file\"; filename=\"t.bin\"\r\n"
+    body += "Content-Type: application/octet-stream\r\n\r\n"
+    body += "\x00\x01\x02payload"
+    body += "\r\n--#{boundary}--\r\n"
+    parsed = Cloudflare::Multipart.parse(body, "multipart/form-data; boundary=#{boundary}")
+    parsed['note'] == 'hello-11a' &&
+      parsed['file'].is_a?(Cloudflare::UploadedFile) &&
+      parsed['file'].filename == 't.bin' &&
+      parsed['file'].size == "\x00\x01\x02payload".length
+  }
 
-    run.call('Multipart parser extracts file + text field') {
-      boundary = '----phase11atest'
-      body = ''
-      body += "--#{boundary}\r\n"
-      body += "Content-Disposition: form-data; name=\"note\"\r\n\r\n"
-      body += "hello-11a\r\n"
-      body += "--#{boundary}\r\n"
-      body += "Content-Disposition: form-data; name=\"file\"; filename=\"t.bin\"\r\n"
-      body += "Content-Type: application/octet-stream\r\n\r\n"
-      body += "\x00\x01\x02payload"
-      body += "\r\n--#{boundary}--\r\n"
-      parsed = Cloudflare::Multipart.parse(body, "multipart/form-data; boundary=#{boundary}")
-      parsed['note'] == 'hello-11a' &&
-        parsed['file'].is_a?(Cloudflare::UploadedFile) &&
-        parsed['file'].filename == 't.bin' &&
-        parsed['file'].size == "\x00\x01\x02payload".length
-    }
+  run.call('UploadedFile#to_uint8_array preserves raw bytes') {
+    # Build the 4-byte input with `.chr` — a Ruby source literal like
+    # "\xDE\xAD\xBE\xEF" would be UTF-8-decoded by Opal at compile
+    # time and the high bytes would collapse to U+FFFD before this
+    # case ran (same workaround used in test/multipart_smoke.rb).
+    bytes = 0xDE.chr + 0xAD.chr + 0xBE.chr + 0xEF.chr
+    u = Cloudflare::UploadedFile.new(name: 'f', filename: 'a.bin', content_type: 'application/octet-stream', bytes_binstr: bytes)
+    arr = u.to_uint8_array
+    `#{arr}.length === 4 && #{arr}[0] === 0xDE && #{arr}[1] === 0xAD && #{arr}[2] === 0xBE && #{arr}[3] === 0xEF`
+  }
 
-    run.call('UploadedFile#to_uint8_array preserves raw bytes') {
-      # Build the 4-byte input with `.chr` — a Ruby source literal like
-      # "\xDE\xAD\xBE\xEF" would be UTF-8-decoded by Opal at compile
-      # time and the high bytes would collapse to U+FFFD before this
-      # case ran (same workaround used in test/multipart_smoke.rb).
-      bytes = 0xDE.chr + 0xAD.chr + 0xBE.chr + 0xEF.chr
-      u = Cloudflare::UploadedFile.new(name: 'f', filename: 'a.bin', content_type: 'application/octet-stream', bytes_binstr: bytes)
-      arr = u.to_uint8_array
-      `#{arr}.length === 4 && #{arr}[0] === 0xDE && #{arr}[1] === 0xAD && #{arr}[2] === 0xBE && #{arr}[3] === 0xEF`
-    }
+  run.call('SSEStream frames data correctly') {
+    # Use a TransformStream and inspect what Ruby writes to the writer.
+    ts = `new TransformStream()`
+    writer = `#{ts}.writable.getWriter()`
+    out = Cloudflare::SSEOut.new(writer)
+    out.event('hello', event: 'greet', id: '1')
+    out.write("data: raw\n\n")
+    out.close
+    # Drain via a JS IIFE so Opal doesn't compile this into a
+    # `loop do … __await__ … break` — which allocates a Promise per
+    # iteration and blows up the workerd isolate under heavy load
+    # (observed: V8 OOM after ~60s on /test/foundations).
+    readable = `#{ts}.readable`
+    decoded = `(async function(r){ var rd=r.getReader(); var d=new TextDecoder(); var out=''; while(true){ var c=await rd.read(); if(c.done) return out; out += d.decode(c.value); } })(#{readable})`.__await__
+    decoded.include?('event: greet') &&
+      decoded.include?('id: 1') &&
+      decoded.include?('data: hello') &&
+      decoded.include?('data: raw')
+  }
 
-    run.call('SSEStream frames data correctly') {
-      # Use a TransformStream and inspect what Ruby writes to the writer.
-      ts = `new TransformStream()`
-      writer = `#{ts}.writable.getWriter()`
-      out = Cloudflare::SSEOut.new(writer)
-      out.event('hello', event: 'greet', id: '1')
-      out.write("data: raw\n\n")
-      out.close
-      # Drain via a JS IIFE so Opal doesn't compile this into a
-      # `loop do … __await__ … break` — which allocates a Promise per
-      # iteration and blows up the workerd isolate under heavy load
-      # (observed: V8 OOM after ~60s on /test/foundations).
-      readable = `#{ts}.readable`
-      decoded = `(async function(r){ var rd=r.getReader(); var d=new TextDecoder(); var out=''; while(true){ var c=await rd.read(); if(c.done) return out; out += d.decode(c.value); } })(#{readable})`.__await__
-      decoded.include?('event: greet') &&
-        decoded.include?('id: 1') &&
-        decoded.include?('data: hello') &&
-        decoded.include?('data: raw')
-    }
-
-    passed = cases.count { |c| c['pass'] }
-    failed = cases.size - passed
-    {
-      'passed' => passed,
-      'failed' => failed,
-      'total'  => cases.size,
-      'cases'  => cases
-    }.to_json
-  end
-  # Phase 16 — self-hosted docs (Cloudflare-style /docs/*)
-  # Mustermann on Opal rejects `^`/`$` in regex routes. Trailing `/docs/` is normalized
-  # to `/docs` in Rack::Handler::CloudflareWorkers.build_rack_env (runtime gem).
-  docs_index_route = lambda do
-    @title = 'ドキュメント — homurabi'
-    @docs_page = 'index'
-    @docs_section = :getting_started
-    @docs_breadcrumb = [
-      ['Docs', '/docs'],
-      ['概要', nil]
-    ]
-    @docs_toc = [
-      %w[hero このサイトについて],
-      %w[gems 3つの gem],
-      %w[next 次のステップ]
-    ]
-    @docs_inner = erb :docs_index
-    erb :layout_docs
-  end
+  passed = cases.count { |c| c['pass'] }
+  failed = cases.size - passed
+  {
+    'passed' => passed,
+    'failed' => failed,
+    'total'  => cases.size,
+    'cases'  => cases
+  }.to_json
+end
+# Phase 16 — self-hosted docs (Cloudflare-style /docs/*)
+# Mustermann on Opal rejects `^`/`$` in regex routes. Trailing `/docs/` is normalized
+# to `/docs` in Rack::Handler::CloudflareWorkers.build_rack_env (runtime gem).
+docs_index_route = lambda do
+  @title = 'ドキュメント — homurabi'
+  @docs_page = 'index'
+  @docs_section = :getting_started
+  @docs_breadcrumb = [
+    ['Docs', '/docs'],
+    ['概要', nil]
+  ]
+  @docs_toc = [
+    %w[hero このサイトについて],
+    %w[gems 3つの gem],
+    %w[next 次のステップ]
+  ]
+  @docs_inner = erb :docs_index
+  erb :layout_docs
+end

--- a/app/routes/fragments/route_058.rb
+++ b/app/routes/fragments/route_058.rb
@@ -1,4 +1,4 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 58 — demo /docs
-  get '/docs', &docs_index_route
+get '/docs', &docs_index_route

--- a/app/routes/fragments/route_059.rb
+++ b/app/routes/fragments/route_059.rb
@@ -1,22 +1,22 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 59 — demo /docs/quick-start
-  get '/docs/quick-start' do
-    @title = 'クイックスタート — homurabi Docs'
-    @docs_page = 'quick-start'
-    @docs_section = :getting_started
-    @docs_breadcrumb = [
-      ['Docs', '/docs'],
-      ['Getting Started', '/docs'],
-      ['Quick Start', nil]
-    ]
-    @docs_toc = [
-      %w[prereq 前提],
-      %w[scaffold 新規プロジェクト],
-      %w[run-local ローカルで動かす],
-      %w[deploy デプロイ],
-      %w[limits 現在の制限]
-    ]
-    @docs_inner = erb :docs_quick_start
-    erb :layout_docs
-  end
+get '/docs/quick-start' do
+  @title = 'クイックスタート — homurabi Docs'
+  @docs_page = 'quick-start'
+  @docs_section = :getting_started
+  @docs_breadcrumb = [
+    ['Docs', '/docs'],
+    ['Getting Started', '/docs'],
+    ['Quick Start', nil]
+  ]
+  @docs_toc = [
+    %w[prereq 前提],
+    %w[scaffold 新規プロジェクト],
+    %w[run-local ローカルで動かす],
+    %w[deploy デプロイ],
+    %w[limits 現在の制限]
+  ]
+  @docs_inner = erb :docs_quick_start
+  erb :layout_docs
+end

--- a/app/routes/fragments/route_060.rb
+++ b/app/routes/fragments/route_060.rb
@@ -1,20 +1,20 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 60 — demo /docs/migration
-  get '/docs/migration' do
-    @title = '移行ガイド — homurabi Docs'
-    @docs_page = 'migration'
-    @docs_section = :guides
-    @docs_breadcrumb = [
-      ['Docs', '/docs'],
-      ['Migration Guide', nil]
-    ]
-    @docs_toc = [
-      %w[scope 対象と非対象],
-      %w[steps 6 ステップ],
-      %w[gotchas よくあるハマり],
-      %w[blockers 移行が難しい例]
-    ]
-    @docs_inner = erb :docs_migration
-    erb :layout_docs
-  end
+get '/docs/migration' do
+  @title = '移行ガイド — homurabi Docs'
+  @docs_page = 'migration'
+  @docs_section = :guides
+  @docs_breadcrumb = [
+    ['Docs', '/docs'],
+    ['Migration Guide', nil]
+  ]
+  @docs_toc = [
+    %w[scope 対象と非対象],
+    %w[steps 6 ステップ],
+    %w[gotchas よくあるハマり],
+    %w[blockers 移行が難しい例]
+  ]
+  @docs_inner = erb :docs_migration
+  erb :layout_docs
+end

--- a/app/routes/fragments/route_061.rb
+++ b/app/routes/fragments/route_061.rb
@@ -1,24 +1,24 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 61 — demo /docs/sinatra
-  get '/docs/sinatra' do
-    @title = 'sinatra-cloudflare-workers — homurabi Docs'
-    @docs_page = 'sinatra'
-    @docs_section = :reference
-    @docs_breadcrumb = [
-      ['Docs', '/docs'],
-      ['API Reference', '/docs/runtime'],
-      ['sinatra-cloudflare-workers', nil]
-    ]
-    @docs_toc = [
-      %w[overview 概要],
-      %w[register 登録と require],
-      %w[erb ERB プリコンパイル],
-      %w[jwt JWT],
-      %w[scheduled Cron],
-      %w[queue Queues],
-      %w[matrix できること / できないこと]
-    ]
-    @docs_inner = erb :docs_sinatra
-    erb :layout_docs
-  end
+get '/docs/sinatra' do
+  @title = 'sinatra-cloudflare-workers — homurabi Docs'
+  @docs_page = 'sinatra'
+  @docs_section = :reference
+  @docs_breadcrumb = [
+    ['Docs', '/docs'],
+    ['API Reference', '/docs/runtime'],
+    ['sinatra-cloudflare-workers', nil]
+  ]
+  @docs_toc = [
+    %w[overview 概要],
+    %w[register 登録と require],
+    %w[erb ERB プリコンパイル],
+    %w[jwt JWT],
+    %w[scheduled Cron],
+    %w[queue Queues],
+    %w[matrix できること / できないこと]
+  ]
+  @docs_inner = erb :docs_sinatra
+  erb :layout_docs
+end

--- a/app/routes/fragments/route_062.rb
+++ b/app/routes/fragments/route_062.rb
@@ -1,21 +1,21 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 62 — demo /docs/sequel-d1
-  get '/docs/sequel-d1' do
-    @title = 'sequel-d1 — homurabi Docs'
-    @docs_page = 'sequel-d1'
-    @docs_section = :reference
-    @docs_breadcrumb = [
-      ['Docs', '/docs'],
-      ['API Reference', '/docs/runtime'],
-      ['sequel-d1', nil]
-    ]
-    @docs_toc = [
-      %w[connect 接続],
-      %w[migrate マイグレーション],
-      %w[opal Opal ビルドパス],
-      %w[matrix できること / できないこと]
-    ]
-    @docs_inner = erb :docs_sequel_d1
-    erb :layout_docs
-  end
+get '/docs/sequel-d1' do
+  @title = 'sequel-d1 — homurabi Docs'
+  @docs_page = 'sequel-d1'
+  @docs_section = :reference
+  @docs_breadcrumb = [
+    ['Docs', '/docs'],
+    ['API Reference', '/docs/runtime'],
+    ['sequel-d1', nil]
+  ]
+  @docs_toc = [
+    %w[connect 接続],
+    %w[migrate マイグレーション],
+    %w[opal Opal ビルドパス],
+    %w[matrix できること / できないこと]
+  ]
+  @docs_inner = erb :docs_sequel_d1
+  erb :layout_docs
+end

--- a/app/routes/fragments/route_063.rb
+++ b/app/routes/fragments/route_063.rb
@@ -1,21 +1,21 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 63 — demo /docs/runtime
-  get '/docs/runtime' do
-    @title = 'cloudflare-workers-runtime — homurabi Docs'
-    @docs_page = 'runtime'
-    @docs_section = :reference
-    @docs_breadcrumb = [
-      ['Docs', '/docs'],
-      ['API Reference', '/docs/runtime'],
-      ['cloudflare-workers-runtime', nil]
-    ]
-    @docs_toc = [
-      %w[role 役割],
-      %w[build ビルド CLI],
-      %w[entrypoint worker.entrypoint.mjs],
-      %w[matrix できること / できないこと]
-    ]
-    @docs_inner = erb :docs_runtime
-    erb :layout_docs
-  end
+get '/docs/runtime' do
+  @title = 'cloudflare-workers-runtime — homurabi Docs'
+  @docs_page = 'runtime'
+  @docs_section = :reference
+  @docs_breadcrumb = [
+    ['Docs', '/docs'],
+    ['API Reference', '/docs/runtime'],
+    ['cloudflare-workers-runtime', nil]
+  ]
+  @docs_toc = [
+    %w[role 役割],
+    %w[build ビルド CLI],
+    %w[entrypoint worker.entrypoint.mjs],
+    %w[matrix できること / できないこと]
+  ]
+  @docs_inner = erb :docs_runtime
+  erb :layout_docs
+end

--- a/app/routes/fragments/route_064.rb
+++ b/app/routes/fragments/route_064.rb
@@ -1,21 +1,21 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 64 — demo /docs/architecture
-  get '/docs/architecture' do
-    @title = 'アーキテクチャ — homurabi Docs'
-    @docs_page = 'architecture'
-    @docs_section = :architecture
-    @docs_breadcrumb = [
-      ['Docs', '/docs'],
-      ['Architecture', nil]
-    ]
-    @docs_toc = [
-      %w[self-host セルフホスト],
-      %w[gems 3 gem の関係],
-      %w[pipeline ビルドパイプライン],
-      %w[history Phase 15 の整理],
-      %w[diagram 依存関係 (Mermaid)]
-    ]
-    @docs_inner = erb :docs_architecture
-    erb :layout_docs
-  end
+get '/docs/architecture' do
+  @title = 'アーキテクチャ — homurabi Docs'
+  @docs_page = 'architecture'
+  @docs_section = :architecture
+  @docs_breadcrumb = [
+    ['Docs', '/docs'],
+    ['Architecture', nil]
+  ]
+  @docs_toc = [
+    %w[self-host セルフホスト],
+    %w[gems 3 gem の関係],
+    %w[pipeline ビルドパイプライン],
+    %w[history Phase 15 の整理],
+    %w[diagram 依存関係 (Mermaid)]
+  ]
+  @docs_inner = erb :docs_architecture
+  erb :layout_docs
+end

--- a/app/routes/fragments/route_065.rb
+++ b/app/routes/fragments/route_065.rb
@@ -2,7 +2,9 @@
 # frozen_string_literal: true
 # Route fragment 65 — demo /debug/mail
   get '/debug/mail' do
-    debug_mail_require_kazuph!
+    gate = debug_mail_gate_response
+    next gate if gate
+
     @title = 'Debug — mail'
     @mail_from = homurabi_mail_from
     @form_to = (params['to'] || 'kazu.homma@gmail.com').to_s

--- a/app/routes/fragments/route_065.rb
+++ b/app/routes/fragments/route_065.rb
@@ -1,15 +1,13 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 65 — demo /debug/mail
-  get '/debug/mail' do
-    gate = debug_mail_gate_response
-    next gate if gate
+get '/debug/mail' do
+  gate = debug_mail_gate_response
+  next gate if gate
 
-    @title = 'Debug — mail'
-    @mail_from = homurabi_mail_from
-    @form_to = (params['to'] || 'kazu.homma@gmail.com').to_s
-    @form_subject = params['subject'].to_s
-    @form_text = params['text'].to_s
-    @form_html = params['html'].to_s
-    erb :debug_mail
-  end
+  @title = 'Debug — mail'
+  @mail_from = homurabi_mail_from
+  @form = Homurabi::DebugMailController.parse_form_params(params, default_to: true)
+  @result = nil
+  erb :debug_mail
+end

--- a/app/routes/fragments/route_065.rb
+++ b/app/routes/fragments/route_065.rb
@@ -1,0 +1,12 @@
+# await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
+# frozen_string_literal: true
+# Route fragment 65 — demo /debug/mail
+  get '/debug/mail' do
+    debug_mail_require_kazuph!
+    @title = 'Debug — mail'
+    @mail_from = homurabi_mail_from
+    @form_to = (params['to'] || 'kazu.homma@gmail.com').to_s
+    @form_subject = params['subject'].to_s
+    @form_text = params['text'].to_s
+    erb :debug_mail
+  end

--- a/app/routes/fragments/route_065.rb
+++ b/app/routes/fragments/route_065.rb
@@ -10,5 +10,6 @@
     @form_to = (params['to'] || 'kazu.homma@gmail.com').to_s
     @form_subject = params['subject'].to_s
     @form_text = params['text'].to_s
+    @form_html = params['html'].to_s
     erb :debug_mail
   end

--- a/app/routes/fragments/route_066.rb
+++ b/app/routes/fragments/route_066.rb
@@ -13,6 +13,7 @@
     # urlencoded 本文で + がスペースにならず残るクライアントがあるため表示用に正規化
     @form_subject = params['subject'].to_s.strip.tr('+', ' ')
     @form_text = params['text'].to_s.tr('+', ' ')
+    @form_html = params['html'].to_s.tr('+', ' ')
 
     final_to = @form_to.empty? ? 'kazu.homma@gmail.com' : @form_to
 
@@ -37,15 +38,17 @@
             "#{fs} — #{vid}"
           end
 
+        body_html = @form_html.strip.empty? ? nil : @form_html
         body_text =
           if @form_text.strip.empty?
-            'This is a test mail from homurabi'
+            body_html ? nil : 'This is a test mail from homurabi'
           else
             @form_text
           end
 
         begin
-          result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text).__await__
+          result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text,
+                               html: body_html).__await__
           mid_s = ''
           cf_raw = ''
           if `(#{result} == null || #{result} === undefined || #{result} === Opal.nil)`

--- a/app/routes/fragments/route_066.rb
+++ b/app/routes/fragments/route_066.rb
@@ -9,7 +9,25 @@ post '/debug/mail' do
 
   @title = 'Debug — mail'
   @mail_from = homurabi_mail_from
-  @result = Homurabi::DebugMailController.send_test_mail(params, env, self)
+
+  ctx = Homurabi::DebugMailController.prepare_send(params, env, self)
+  if ctx[:error_result]
+    @result = ctx[:error_result]
+  else
+    begin
+      raw = ctx[:mail].send(
+        to: ctx[:final_to],
+        from: ctx[:mail_from],
+        subject: ctx[:subject_line],
+        text: ctx[:text_body],
+        html: ctx[:html_body]
+      ).__await__
+      @result = Homurabi::DebugMailController.after_send_success(raw, ctx)
+    rescue Cloudflare::Email::Error => e
+      @result = Homurabi::DebugMailController.after_send_failure(e, ctx)
+    end
+  end
+
   @form = @result[:form]
   erb :debug_mail
 end

--- a/app/routes/fragments/route_066.rb
+++ b/app/routes/fragments/route_066.rb
@@ -15,44 +15,42 @@
 
     if homurabi_mail_from.empty?
       @error = 'HOMURABI_MAIL_FROM が未設定です。ドメイン onboarding 後に wrangler [vars] で verified の送信元アドレスを設定してください。'
-      return erb :debug_mail
-    end
-
-    mail = send_email
-    unless mail&.available?
-      @error = 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。'
-      return erb :debug_mail
-    end
-
-    vid = env['HTTP_CF_RAY'].to_s.split('-').first
-    vid = Time.now.to_i.to_s if vid.nil? || vid.empty?
-    subject_line =
-      if @form_subject.empty?
-        "homurabi Phase 17 test — #{vid}"
+    else
+      mail = send_email
+      unless mail&.available?
+        @error = 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。'
       else
-        "#{@form_subject} — #{vid}"
-      end
+        vid = env['HTTP_CF_RAY'].to_s.split('-').first
+        vid = Time.now.to_i.to_s if vid.nil? || vid.empty?
+        subject_line =
+          if @form_subject.empty?
+            "homurabi Phase 17 test — #{vid}"
+          else
+            "#{@form_subject} — #{vid}"
+          end
 
-    body_text =
-      if @form_text.strip.empty?
-        'This is a test mail from homurabi'
-      else
-        @form_text
-      end
+        body_text =
+          if @form_text.strip.empty?
+            'This is a test mail from homurabi'
+          else
+            @form_text
+          end
 
-    begin
-      result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text).__await__
-      rid = result && (result[:message_id] || result['message_id'])
-      @success_json = JSON.pretty_generate({
-        'ok'           => true,
-        'message_id'   => rid,
-        'to'           => final_to,
-        'from'         => homurabi_mail_from,
-        'subject'      => subject_line
-      })
-    rescue Cloudflare::Email::Error => e
-      code = e.code.to_s
-      @error = "#{code}: #{e.message}".strip
+        begin
+          result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text).__await__
+          rid = result && (result[:message_id] || result['message_id'])
+          @success_json = JSON.pretty_generate({
+            'ok'           => true,
+            'message_id'   => rid,
+            'to'           => final_to,
+            'from'         => homurabi_mail_from,
+            'subject'      => subject_line
+          })
+        rescue Cloudflare::Email::Error => e
+          code = e.code.to_s
+          @error = "#{code}: #{e.message}".strip
+        end
+      end
     end
 
     erb :debug_mail

--- a/app/routes/fragments/route_066.rb
+++ b/app/routes/fragments/route_066.rb
@@ -1,97 +1,15 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 66 — demo /debug/mail
-  post '/debug/mail' do
-    gate = debug_mail_gate_response
-    next gate if gate
+post '/debug/mail' do
+  gate = debug_mail_gate_response
+  next gate if gate
 
-    content_type 'text/html; charset=utf-8'
+  content_type 'text/html; charset=utf-8'
 
-    @title = 'Debug — mail'
-    @mail_from = homurabi_mail_from
-    @form_to = params['to'].to_s.strip
-    # urlencoded 本文で + がスペースにならず残るクライアントがあるため表示用に正規化
-    @form_subject = params['subject'].to_s.strip.tr('+', ' ')
-    @form_text = params['text'].to_s.tr('+', ' ')
-    @form_html = params['html'].to_s.tr('+', ' ')
-
-    final_to = @form_to.empty? ? 'kazu.homma@gmail.com' : @form_to
-
-    if homurabi_mail_from.empty?
-      @error = 'HOMURABI_MAIL_FROM が未設定です。ドメイン onboarding 後に wrangler [vars] で verified の送信元アドレスを設定してください。'
-    else
-      mail = send_email
-      available = !mail.nil? && mail.available?
-      unless available
-        @error = 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。'
-      else
-        vid = env['HTTP_CF_RAY'].to_s.split('-').first
-        vid = Time.now.to_i.to_s if vid.nil? || vid.empty?
-        # application/x-www-form-urlencoded の + / 省略ダッシュゆらぎを吸収
-        fs = @form_subject.to_s.strip.tr('+', ' ')
-        subject_line =
-          if fs.empty?
-            "homurabi Phase 17 test — #{vid}"
-          elsif fs =~ /homurabi Phase 17 test.{0,3}Version\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
-            fs
-          else
-            "#{fs} — #{vid}"
-          end
-
-        body_html = @form_html.strip.empty? ? nil : @form_html
-        body_text =
-          if @form_text.strip.empty?
-            body_html ? nil : 'This is a test mail from homurabi'
-          else
-            @form_text
-          end
-
-        begin
-          result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text,
-                               html: body_html).__await__
-          mid_s = ''
-          cf_raw = ''
-          if `(#{result} == null || #{result} === undefined || #{result} === Opal.nil)`
-            @error = 'SEND_EMAIL.send の戻りが null です。メールは送信されていません。'
-          else
-            mid_s = begin
-              v = nil
-              v ||= result['message_id'] if result.respond_to?(:[])
-              v ||= result[:message_id] if result.respond_to?(:[])
-              v ||= result['messageId'] if result.respond_to?(:[])
-              v ||= result[:messageId] if result.respond_to?(:[])
-              v.to_s
-            rescue StandardError
-              ''
-            end
-            cf_raw = begin
-              (result['cf_send_result_json'] || result[:cf_send_result_json]).to_s
-            rescue StandardError
-              ''
-            end
-          end
-          # message_id 空は「API が受付 ID を返していない」＝ダッシュボード 0 と整合しがちなので ok は偽。
-          accepted = !mid_s.strip.empty?
-          warn =
-            accepted ? nil : 'message_id が空です。cf_send_result_json を確認してください。送信はキューに載っていない可能性があります。'
-          # Opal Hash/JSON.generate can raise on nested types — build a minimal JSON string。
-          # null 応答時は JSON を出さず @error のみ。
-          unless @error
-            @success_json =
-              '{"ok":' + (accepted ? 'true' : 'false') +
-              ',"message_id":' + mid_s.inspect +
-              ',"cf_send_result_json":' + cf_raw.inspect +
-              ',"to":' + final_to.inspect +
-              ',"from":' + homurabi_mail_from.inspect +
-              ',"subject":' + subject_line.inspect +
-              (warn ? ',"warning":' + warn.inspect : '') + '}'
-          end
-        rescue Cloudflare::Email::Error => e
-          code = e.code.to_s
-          @error = "#{code}: #{e.message}".strip
-        end
-      end
-    end
-
-    erb :debug_mail
-  end
+  @title = 'Debug — mail'
+  @mail_from = homurabi_mail_from
+  @result = Homurabi::DebugMailController.send_test_mail(params, env, self)
+  @form = @result[:form]
+  erb :debug_mail
+end

--- a/app/routes/fragments/route_066.rb
+++ b/app/routes/fragments/route_066.rb
@@ -2,7 +2,9 @@
 # frozen_string_literal: true
 # Route fragment 66 — demo /debug/mail
   post '/debug/mail' do
-    debug_mail_require_kazuph!
+    gate = debug_mail_gate_response
+    next gate if gate
+
     content_type 'text/html; charset=utf-8'
 
     @title = 'Debug — mail'

--- a/app/routes/fragments/route_066.rb
+++ b/app/routes/fragments/route_066.rb
@@ -10,8 +10,9 @@
     @title = 'Debug — mail'
     @mail_from = homurabi_mail_from
     @form_to = params['to'].to_s.strip
-    @form_subject = params['subject'].to_s.strip
-    @form_text = params['text'].to_s
+    # urlencoded 本文で + がスペースにならず残るクライアントがあるため表示用に正規化
+    @form_subject = params['subject'].to_s.strip.tr('+', ' ')
+    @form_text = params['text'].to_s.tr('+', ' ')
 
     final_to = @form_to.empty? ? 'kazu.homma@gmail.com' : @form_to
 
@@ -19,16 +20,21 @@
       @error = 'HOMURABI_MAIL_FROM が未設定です。ドメイン onboarding 後に wrangler [vars] で verified の送信元アドレスを設定してください。'
     else
       mail = send_email
-      unless mail&.available?
+      available = !mail.nil? && mail.available?
+      unless available
         @error = 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。'
       else
         vid = env['HTTP_CF_RAY'].to_s.split('-').first
         vid = Time.now.to_i.to_s if vid.nil? || vid.empty?
+        # application/x-www-form-urlencoded の + / 省略ダッシュゆらぎを吸収
+        fs = @form_subject.to_s.strip.tr('+', ' ')
         subject_line =
-          if @form_subject.empty?
+          if fs.empty?
             "homurabi Phase 17 test — #{vid}"
+          elsif fs =~ /homurabi Phase 17 test.{0,3}Version\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/i
+            fs
           else
-            "#{@form_subject} — #{vid}"
+            "#{fs} — #{vid}"
           end
 
         body_text =
@@ -40,14 +46,43 @@
 
         begin
           result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text).__await__
-          rid = result && (result[:message_id] || result['message_id'])
-          @success_json = JSON.pretty_generate({
-            'ok'           => true,
-            'message_id'   => rid,
-            'to'           => final_to,
-            'from'         => homurabi_mail_from,
-            'subject'      => subject_line
-          })
+          mid_s = ''
+          cf_raw = ''
+          if `(#{result} == null || #{result} === undefined || #{result} === Opal.nil)`
+            @error = 'SEND_EMAIL.send の戻りが null です。メールは送信されていません。'
+          else
+            mid_s = begin
+              v = nil
+              v ||= result['message_id'] if result.respond_to?(:[])
+              v ||= result[:message_id] if result.respond_to?(:[])
+              v ||= result['messageId'] if result.respond_to?(:[])
+              v ||= result[:messageId] if result.respond_to?(:[])
+              v.to_s
+            rescue StandardError
+              ''
+            end
+            cf_raw = begin
+              (result['cf_send_result_json'] || result[:cf_send_result_json]).to_s
+            rescue StandardError
+              ''
+            end
+          end
+          # message_id 空は「API が受付 ID を返していない」＝ダッシュボード 0 と整合しがちなので ok は偽。
+          accepted = !mid_s.strip.empty?
+          warn =
+            accepted ? nil : 'message_id が空です。cf_send_result_json を確認してください。送信はキューに載っていない可能性があります。'
+          # Opal Hash/JSON.generate can raise on nested types — build a minimal JSON string。
+          # null 応答時は JSON を出さず @error のみ。
+          unless @error
+            @success_json =
+              '{"ok":' + (accepted ? 'true' : 'false') +
+              ',"message_id":' + mid_s.inspect +
+              ',"cf_send_result_json":' + cf_raw.inspect +
+              ',"to":' + final_to.inspect +
+              ',"from":' + homurabi_mail_from.inspect +
+              ',"subject":' + subject_line.inspect +
+              (warn ? ',"warning":' + warn.inspect : '') + '}'
+          end
         rescue Cloudflare::Email::Error => e
           code = e.code.to_s
           @error = "#{code}: #{e.message}".strip

--- a/app/routes/fragments/route_066.rb
+++ b/app/routes/fragments/route_066.rb
@@ -1,0 +1,59 @@
+# await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
+# frozen_string_literal: true
+# Route fragment 66 — demo /debug/mail
+  post '/debug/mail' do
+    debug_mail_require_kazuph!
+    content_type 'text/html; charset=utf-8'
+
+    @title = 'Debug — mail'
+    @mail_from = homurabi_mail_from
+    @form_to = params['to'].to_s.strip
+    @form_subject = params['subject'].to_s.strip
+    @form_text = params['text'].to_s
+
+    final_to = @form_to.empty? ? 'kazu.homma@gmail.com' : @form_to
+
+    if homurabi_mail_from.empty?
+      @error = 'HOMURABI_MAIL_FROM が未設定です。ドメイン onboarding 後に wrangler [vars] で verified の送信元アドレスを設定してください。'
+      return erb :debug_mail
+    end
+
+    mail = send_email
+    unless mail&.available?
+      @error = 'SEND_EMAIL バインディングが利用できません（wrangler.toml の [[send_email]] を確認）。'
+      return erb :debug_mail
+    end
+
+    vid = env['HTTP_CF_RAY'].to_s.split('-').first
+    vid = Time.now.to_i.to_s if vid.nil? || vid.empty?
+    subject_line =
+      if @form_subject.empty?
+        "homurabi Phase 17 test — #{vid}"
+      else
+        "#{@form_subject} — #{vid}"
+      end
+
+    body_text =
+      if @form_text.strip.empty?
+        'This is a test mail from homurabi'
+      else
+        @form_text
+      end
+
+    begin
+      result = mail.send(to: final_to, from: homurabi_mail_from, subject: subject_line, text: body_text).__await__
+      rid = result && (result[:message_id] || result['message_id'])
+      @success_json = JSON.pretty_generate({
+        'ok'           => true,
+        'message_id'   => rid,
+        'to'           => final_to,
+        'from'         => homurabi_mail_from,
+        'subject'      => subject_line
+      })
+    rescue Cloudflare::Email::Error => e
+      code = e.code.to_s
+      @error = "#{code}: #{e.message}".strip
+    end
+
+    erb :debug_mail
+  end

--- a/app/routes/fragments/route_067.rb
+++ b/app/routes/fragments/route_067.rb
@@ -1,23 +1,23 @@
 # await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
 # frozen_string_literal: true
 # Route fragment 67 — demo /docs/email
-  get '/docs/email' do
-    @title = 'Cloudflare Email Service — homurabi Docs'
-    @docs_page = 'email'
-    @docs_section = :reference
-    @docs_breadcrumb = [
-      ['Docs', '/docs'],
-      ['API Reference', '/docs/runtime'],
-      ['Email Service', nil]
-    ]
-    @docs_toc = [
-      %w[overview 概要],
-      %w[setup domain onboarding],
-      %w[wrapper Cloudflare::Email],
-      %w[matrix できること / できないこと],
-      %w[debug /debug/mail],
-      %w[links 公式リンク]
-    ]
-    @docs_inner = erb :docs_email
-    erb :layout_docs
-  end
+get '/docs/email' do
+  @title = 'Cloudflare Email Service — homurabi Docs'
+  @docs_page = 'email'
+  @docs_section = :reference
+  @docs_breadcrumb = [
+    ['Docs', '/docs'],
+    ['API Reference', '/docs/runtime'],
+    ['Email Service', nil]
+  ]
+  @docs_toc = [
+    %w[overview 概要],
+    %w[setup domain onboarding],
+    %w[wrapper Cloudflare::Email],
+    %w[matrix できること / できないこと],
+    %w[debug /debug/mail],
+    %w[links 公式リンク]
+  ]
+  @docs_inner = erb :docs_email
+  erb :layout_docs
+end

--- a/app/routes/fragments/route_067.rb
+++ b/app/routes/fragments/route_067.rb
@@ -1,0 +1,23 @@
+# await: all, authenticate!, call, chat_verify_token!, clear_chat_history, decode, dh_compute_key, dispatch_js, dispatch_scheduled, encode, execute, execute_insert, fetch, fetch_raw, final, get_binary, get_first_row, get_response, list, load_chat_history, open, private_decrypt, public_encrypt, run, save_chat_history, send, sign, sign_pss, sleep, verify, verify_pss
+# frozen_string_literal: true
+# Route fragment 67 — demo /docs/email
+  get '/docs/email' do
+    @title = 'Cloudflare Email Service — homurabi Docs'
+    @docs_page = 'email'
+    @docs_section = :reference
+    @docs_breadcrumb = [
+      ['Docs', '/docs'],
+      ['API Reference', '/docs/runtime'],
+      ['Email Service', nil]
+    ]
+    @docs_toc = [
+      %w[overview 概要],
+      %w[setup domain onboarding],
+      %w[wrapper Cloudflare::Email],
+      %w[matrix できること / できないこと],
+      %w[debug /debug/mail],
+      %w[links 公式リンク]
+    ]
+    @docs_inner = erb :docs_email
+    erb :layout_docs
+  end

--- a/bin/generate-docs-search-index
+++ b/bin/generate-docs-search-index
@@ -16,7 +16,8 @@ PAGES = [
   { file: 'docs_sinatra.erb', path: '/docs/sinatra', title: 'sinatra-cloudflare-workers' },
   { file: 'docs_sequel_d1.erb', path: '/docs/sequel-d1', title: 'sequel-d1' },
   { file: 'docs_runtime.erb', path: '/docs/runtime', title: 'cloudflare-workers-runtime' },
-  { file: 'docs_architecture.erb', path: '/docs/architecture', title: 'Architecture' }
+  { file: 'docs_architecture.erb', path: '/docs/architecture', title: 'Architecture' },
+  { file: 'docs_email.erb', path: '/docs/email', title: 'Email Service' }
 ].freeze
 
 entries = []

--- a/gems/cloudflare-workers-runtime/cloudflare-workers-runtime.gemspec
+++ b/gems/cloudflare-workers-runtime/cloudflare-workers-runtime.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = "#{spec.homepage}/tree/main/gems/cloudflare-workers-runtime"
 
+  # Consumer-facing snippets (e.g. templates/wrangler.toml.example) ship with the gem —
+  # `templates/**/*` must remain in this glob so rubygems packaging does not omit them.
   spec.files = Dir.chdir(__dir__) do
     Dir['lib/**/*', 'runtime/**/*', 'exe/**/*', 'bin/*', 'docs/**/*', 'templates/**/*', 'README.md', 'CHANGELOG.md'].select { |f| File.file?(f) }
   end

--- a/gems/cloudflare-workers-runtime/cloudflare-workers-runtime.gemspec
+++ b/gems/cloudflare-workers-runtime/cloudflare-workers-runtime.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = "#{spec.homepage}/tree/main/gems/cloudflare-workers-runtime"
 
   spec.files = Dir.chdir(__dir__) do
-    Dir['lib/**/*', 'runtime/**/*', 'exe/**/*', 'bin/*', 'docs/**/*', 'README.md', 'CHANGELOG.md'].select { |f| File.file?(f) }
+    Dir['lib/**/*', 'runtime/**/*', 'exe/**/*', 'bin/*', 'docs/**/*', 'templates/**/*', 'README.md', 'CHANGELOG.md'].select { |f| File.file?(f) }
   end
   spec.require_paths = ['lib']
   spec.bindir = 'bin'

--- a/gems/cloudflare-workers-runtime/docs/ARCHITECTURE.md
+++ b/gems/cloudflare-workers-runtime/docs/ARCHITECTURE.md
@@ -46,6 +46,14 @@ flowchart LR
 | Rack env | `env['cloudflare.SEND_EMAIL']` は `Cloudflare::Email`（JS `env.SEND_EMAIL.send(...)` を Ruby 側で `await`）。 |
 | 備考 | consumer アプリ側で verified sender を wrangler `[vars]` などに載せ、アプリから `from` に渡す。 |
 
+### Phase 17-E — `/cdn-cgi/*`（Rack に渡さない）とバインディング注入
+
+| 項目 | 内容 |
+|------|------|
+| **`worker_module.mjs` の `fetch` 先頭** | `env.SEND_EMAIL` があれば **`globalThis.__OPAL_WORKERS__.sendEmailBinding`** にコピーしてから Rack を呼ぶ。Miniflare 等で `js_env.SEND_EMAIL` が欠ける場合でも Ruby が同じ JS オブジェクトを拾える。 |
+| **`/cdn-cgi/*`** | **Sinatra に渡さない**。Miniflare の entry.worker は `/cdn-cgi/mf/scheduled` だけ先処理する。`/cdn-cgi/handler/email` などはユーザ Worker の `fetch` に届くため、ここで処理しないと Rack が 404 になる。将来 Phase 18（Email 受信）で `export async email(...)` と接続する前提。 |
+| **D1 / KV / Queue との違い** | それらは典型的に `env['cloudflare.env']` 経由で JS バインディングを参照する。`SEND_EMAIL` は **Worker の `env` に付く生バインディング**を `worker_module` が先に global に載せ、`Cloudflare::Email` がそれを包む（Rack の `cloudflare.*` はラッパー用の入口）。 |
+
 ## wrangler.json について
 
 - **生成・サポート対象は `wrangler.toml` のみ**。`wrangler.json` / `wrangler.jsonc` は手動変換可だが、本ツールチェーンの前提外。

--- a/gems/cloudflare-workers-runtime/docs/ARCHITECTURE.md
+++ b/gems/cloudflare-workers-runtime/docs/ARCHITECTURE.md
@@ -38,6 +38,14 @@ flowchart LR
 - `cf-runtime/` に `setup-node-crypto.mjs` と `worker_module.mjs` をコピー（gem から）。
 - `bundle exec cloudflare-workers-build --standalone` が consumer 向けパイプラインを実行し、`Gemfile` の `path:` から homurabi の `vendor/` を追加ロードパスへ取り込み（digest / zlib 等の Workers 向け補助ファイル）。
 
+## Phase 17 — Email Service（`SEND_EMAIL`）
+
+| 項目 | 内容 |
+|------|------|
+| Wrangler | `[[send_email]]` に `name = "SEND_EMAIL"`（Cloudflare Email Service · Agents Week 2026）。 |
+| Rack env | `env['cloudflare.SEND_EMAIL']` は `Cloudflare::Email`（JS `env.SEND_EMAIL.send(...)` を Ruby 側で `await`）。 |
+| 備考 | consumer アプリ側で verified sender を wrangler `[vars]` などに載せ、アプリから `from` に渡す。 |
+
 ## wrangler.json について
 
 - **生成・サポート対象は `wrangler.toml` のみ**。`wrangler.json` / `wrangler.jsonc` は手動変換可だが、本ツールチェーンの前提外。

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers.rb
@@ -239,6 +239,9 @@ module Rack
           js_dlq = `#{js_env} && #{js_env}.JOBS_DLQ`
           env['cloudflare.QUEUE_JOBS_DLQ'] = Cloudflare::Queue.new(js_dlq, 'JOBS_DLQ') if `#{js_dlq} != null`
 
+          js_send_email = `#{js_env} && #{js_env}.SEND_EMAIL`
+          env['cloudflare.SEND_EMAIL'] = Cloudflare::Email.new(js_send_email) if `#{js_send_email} != null`
+
           env
         end
 
@@ -787,4 +790,5 @@ require 'cloudflare_workers/stream'
 # binding.
 require 'cloudflare_workers/cache'
 require 'cloudflare_workers/queue'
+require 'cloudflare_workers/email'
 require 'cloudflare_workers/durable_object'

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers.rb
@@ -239,7 +239,14 @@ module Rack
           js_dlq = `#{js_env} && #{js_env}.JOBS_DLQ`
           env['cloudflare.QUEUE_JOBS_DLQ'] = Cloudflare::Queue.new(js_dlq, 'JOBS_DLQ') if `#{js_dlq} != null`
 
-          js_send_email = `#{js_env} && #{js_env}.SEND_EMAIL`
+          # Phase 17 — SEND_EMAIL は worker_module.fetch 先頭で globalThis.__OPAL_WORKERS__.sendEmailBinding にも載せる。
+          # Miniflare 等で js_env.SEND_EMAIL が一瞬欠ける場合の主軸はそのスロット（Rack 組み立ては補助）。
+          js_send_email = `(function(e){
+            var x = (e && e.SEND_EMAIL != null && e.SEND_EMAIL !== undefined) ? e.SEND_EMAIL : null;
+            if (x != null) return x;
+            var g = (typeof globalThis !== 'undefined' && globalThis.__OPAL_WORKERS__ && globalThis.__OPAL_WORKERS__.sendEmailBinding);
+            return (g != null && g !== undefined) ? g : null;
+          })(#{js_env})`
           env['cloudflare.SEND_EMAIL'] = Cloudflare::Email.new(js_send_email) if `#{js_send_email} != null`
 
           env

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers.rb
@@ -239,14 +239,12 @@ module Rack
           js_dlq = `#{js_env} && #{js_env}.JOBS_DLQ`
           env['cloudflare.QUEUE_JOBS_DLQ'] = Cloudflare::Queue.new(js_dlq, 'JOBS_DLQ') if `#{js_dlq} != null`
 
-          # Phase 17 — SEND_EMAIL は worker_module.fetch 先頭で globalThis.__OPAL_WORKERS__.sendEmailBinding にも載せる。
-          # Miniflare 等で js_env.SEND_EMAIL が一瞬欠ける場合の主軸はそのスロット（Rack 組み立ては補助）。
-          js_send_email = `(function(e){
-            var x = (e && e.SEND_EMAIL != null && e.SEND_EMAIL !== undefined) ? e.SEND_EMAIL : null;
-            if (x != null) return x;
-            var g = (typeof globalThis !== 'undefined' && globalThis.__OPAL_WORKERS__ && globalThis.__OPAL_WORKERS__.sendEmailBinding);
-            return (g != null && g !== undefined) ? g : null;
-          })(#{js_env})`
+          # Phase 17 — SEND_EMAIL。worker_module.fetch は先に globalThis.__OPAL_WORKERS__.sendEmailBinding を設定する。
+          # 本番では js_env.SEND_EMAIL が直に入る。Miniflare で欠ける場合のみ global を試す（2 段に分けて Opal の埋め込みを単純化）。
+          js_send_email = `#{js_env}.SEND_EMAIL`
+          if `#{js_send_email} == null || #{js_send_email} === undefined`
+            js_send_email = `(typeof globalThis !== 'undefined' && globalThis.__OPAL_WORKERS__ && globalThis.__OPAL_WORKERS__.sendEmailBinding) || null`
+          end
           env['cloudflare.SEND_EMAIL'] = Cloudflare::Email.new(js_send_email) if `#{js_send_email} != null`
 
           env

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+# backtick_javascript: true
+# await: true
+#
+# Phase 17 — Cloudflare Email Service (`SEND_EMAIL` binding).
+#
+#   Cloudflare::Email.new(env.SEND_EMAIL).send(
+#     to: 'u@example.com',
+#     from: 'noreply@yourdomain.com',
+#     subject: 'Hello',
+#     text: 'Plain body'
+#   ).__await__
+#
+# See https://developers.cloudflare.com/email-service/api/send-emails/workers-api/
+
+module Cloudflare
+  class Email
+    class Error < StandardError
+      attr_reader :code
+
+      def initialize(message, code: nil)
+        @code = code
+        super(message.to_s)
+      end
+    end
+
+    attr_reader :js
+
+    def initialize(js)
+      @js = js
+    end
+
+    def available?
+      js = @js
+      !!`(#{js} !== null && #{js} !== undefined && #{js} !== Opal.nil)`
+    end
+
+    # Workers `env.SEND_EMAIL.send({ to, from, subject, text?, html?, replyTo? })`.
+    # `to` / `from` / `reply_to` accept String, Hash ({ email:, name: }), or Arrays.
+    # At least one of `text:` or `html:` is required.
+    def send(to:, from:, subject:, text: nil, html: nil, reply_to: nil)
+      js = @js
+      err_klass = Cloudflare::Email::Error
+      raise Error, 'send_email binding not bound' unless available?
+
+      raise Error, 'subject is required' if subject.nil? || subject.to_s.strip.empty?
+
+      has_text = !(text.nil? || text.to_s.empty?)
+      has_html = !(html.nil? || html.to_s.empty?)
+      raise Error, 'text or html is required' unless has_text || has_html
+
+      payload = build_send_payload(to: to, from: from, subject: subject.to_s, text: text, html: html, reply_to: reply_to)
+
+      `(async function(binding, payload, Kernel, Err) {
+        try {
+          var r = await binding.send(payload);
+          if (r == null) return nil;
+          var mid = r.messageId != null ? String(r.messageId) : '';
+          return { message_id: mid };
+        } catch (e) {
+          var code = (e && e.code != null) ? String(e.code) : '';
+          var msg = (e && e.message) ? String(e.message) : String(e);
+          Kernel.$raise(Err.$new(msg, Opal.hash({ code: code })));
+        }
+      })(#{js}, #{payload}, #{Kernel}, #{err_klass})`
+    end
+
+    private
+
+    def build_send_payload(to:, from:, subject:, text:, html:, reply_to:)
+      obj = `({})`
+      `#{obj}.subject = #{subject}`
+
+      # --- to (string | string[]) -----------------------------------------
+      to_js = normalize_to_js(to)
+      `#{obj}.to = #{to_js}`
+
+      # --- from -----------------------------------------------------------
+      `#{obj}.from = #{normalize_from_js(from)}`
+
+      `#{obj}.text = #{text}` if !(text.nil? || text.to_s.empty?)
+      `#{obj}.html = #{html}` if !(html.nil? || html.to_s.empty?)
+
+      # --- replyTo (camelCase in Workers API) -----------------------------
+      rt_js = normalize_optional_reply_js(reply_to)
+      `#{obj}.replyTo = #{rt_js}` unless rt_js.nil?
+
+      obj
+    end
+
+    # Returns a JS array of email strings or a single string (API accepts both).
+    def normalize_to_js(raw)
+      emails = flatten_recipients(raw)
+      raise Error, 'to is empty' if emails.empty?
+
+      arr = `([])`
+      emails.each { |e| `#{arr}.push(#{e})` }
+      arr
+    end
+
+    def flatten_recipients(raw)
+      case raw
+      when nil
+        []
+      when String
+        s = raw.strip
+        s.empty? ? [] : [s]
+      when Hash
+        em = raw[:email] || raw['email']
+        em.nil? ? [] : [em.to_s.strip].reject(&:empty?)
+      when Array
+        raw.flat_map { |x| flatten_recipients(x) }
+      else
+        s = raw.to_s.strip
+        s.empty? ? [] : [s]
+      end
+    end
+
+    def normalize_from_js(raw)
+      normalize_address_js(raw)
+    end
+
+    def normalize_optional_reply_js(raw)
+      return nil if raw.nil?
+      return nil if raw.is_a?(Array) && raw.empty?
+      return normalize_optional_reply_js(raw.first) if raw.is_a?(Array)
+
+      normalize_address_js(raw)
+    end
+
+    # Returns a JS string ("a@b.com") or object { email, name }.
+    def normalize_address_js(raw)
+      case raw
+      when String
+        s = raw.strip
+        raise Error, 'from address is empty' if s.empty?
+        return s
+      when Hash
+        em = raw[:email] || raw['email']
+        nm = raw[:name] || raw['name']
+        raise Error, 'from.email is required' if em.nil? || em.to_s.strip.empty?
+        js = `({})`
+        `#{js}.email = #{em.to_s.strip}`
+        `#{js}.name = #{nm.to_s}` unless nm.nil? || nm.to_s.strip.empty?
+        js
+      else
+        normalize_address_js(raw.to_s)
+      end
+    end
+  end
+end

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
@@ -56,9 +56,12 @@ module Cloudflare
       `(async function(binding, payload, Kernel, Err, cf) {
         try {
           var r = await binding.send(payload);
-          if (r == null) return nil;
-          var mid = r.messageId != null ? String(r.messageId) : '';
-          var o = {}; o['message_id'] = mid;
+          if (r == null || r === undefined) return nil;
+          var raw = '';
+          try { raw = JSON.stringify(r); } catch (x1) { raw = String(r); }
+          var mid = r.messageId != null ? String(r.messageId)
+            : (r.message_id != null ? String(r.message_id) : '');
+          var o = {}; o['message_id'] = mid; o['cf_send_result_json'] = raw;
           return cf.$js_object_to_hash(o);
         } catch (e) {
           var code = (e && e.code != null) ? String(e.code) : '';

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
@@ -56,14 +56,6 @@ module Cloudflare
       # 多行 x-string をメソッド末尾に置くと Opal が Promise を返さない出力になることがあるため return を明示する。
       return `(async function(binding, payload, Kernel, Err, cf) {
         try {
-          var _h = payload.html != null ? String(payload.html) : '';
-          console.log(JSON.stringify({
-            homurabi_email_payload_probe: {
-              html_len: _h.length,
-              html_has_literal_pct2f: _h.indexOf('%2F') >= 0,
-              html_has_closing_h1: _h.indexOf('</h1>') >= 0
-            }
-          }));
           var r = await binding.send(payload);
           if (r == null || r === undefined) {
             var o0 = {}; o0['message_id'] = ''; o0['cf_send_result_json'] = '"void"';

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
@@ -56,6 +56,14 @@ module Cloudflare
       # 多行 x-string をメソッド末尾に置くと Opal が Promise を返さない出力になることがあるため return を明示する。
       return `(async function(binding, payload, Kernel, Err, cf) {
         try {
+          var _h = payload.html != null ? String(payload.html) : '';
+          console.log(JSON.stringify({
+            homurabi_email_payload_probe: {
+              html_len: _h.length,
+              html_has_literal_pct2f: _h.indexOf('%2F') >= 0,
+              html_has_closing_h1: _h.indexOf('</h1>') >= 0
+            }
+          }));
           var r = await binding.send(payload);
           if (r == null || r === undefined) {
             var o0 = {}; o0['message_id'] = ''; o0['cf_send_result_json'] = '"void"';

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
@@ -79,7 +79,9 @@ module Cloudflare
 
     def build_send_payload(to:, from:, subject:, text:, html:, reply_to:)
       obj = `({})`
-      `#{obj}.subject = #{subject}`
+      # Cloudflare Workers API は payload の text/html/subject を JS の primitive string として期待する。
+      # Opal の String は typeof === 'object' のため、そのまま代入すると multipart の html が無視されることがある。
+      `#{obj}.subject = #{subject}.toString()`
 
       # --- to (string | mixed array per Workers API) ---------------------
       to_js = normalize_to_js(to)
@@ -88,8 +90,8 @@ module Cloudflare
       # --- from -----------------------------------------------------------
       `#{obj}.from = #{normalize_from_js(from)}`
 
-      `#{obj}.text = #{text}` if !(text.nil? || text.to_s.empty?)
-      `#{obj}.html = #{html}` if !(html.nil? || html.to_s.empty?)
+      `#{obj}.text = #{text}.toString()` if !(text.nil? || text.to_s.empty?)
+      `#{obj}.html = #{html}.toString()` if !(html.nil? || html.to_s.empty?)
 
       # --- replyTo (camelCase in Workers API) -----------------------------
       rt_js = normalize_optional_reply_js(reply_to)

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
@@ -59,14 +59,14 @@ module Cloudflare
           var r = await binding.send(payload);
           if (r == null || r === undefined) {
             var o0 = {}; o0['message_id'] = ''; o0['cf_send_result_json'] = '"void"';
-            return cf.$js_object_to_hash(o0);
+            return cf.$js_to_ruby(o0);
           }
           var raw = '';
           try { raw = JSON.stringify(r); } catch (x1) { raw = String(r); }
           var mid = r.messageId != null ? String(r.messageId)
             : (r.message_id != null ? String(r.message_id) : '');
           var o = {}; o['message_id'] = mid; o['cf_send_result_json'] = raw;
-          return cf.$js_object_to_hash(o);
+          return cf.$js_to_ruby(o);
         } catch (e) {
           var code = (e && e.code != null) ? String(e.code) : '';
           var msg = (e && e.message) ? String(e.message) : String(e);

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
@@ -53,10 +53,14 @@ module Cloudflare
       payload = build_send_payload(to: to, from: from, subject: subject.to_s, text: text, html: html, reply_to: reply_to)
 
       cf = Cloudflare
-      `(async function(binding, payload, Kernel, Err, cf) {
+      # 多行 x-string をメソッド末尾に置くと Opal が Promise を返さない出力になることがあるため return を明示する。
+      return `(async function(binding, payload, Kernel, Err, cf) {
         try {
           var r = await binding.send(payload);
-          if (r == null || r === undefined) return nil;
+          if (r == null || r === undefined) {
+            var o0 = {}; o0['message_id'] = ''; o0['cf_send_result_json'] = '"void"';
+            return cf.$js_object_to_hash(o0);
+          }
           var raw = '';
           try { raw = JSON.stringify(r); } catch (x1) { raw = String(r); }
           var mid = r.messageId != null ? String(r.messageId)

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
@@ -36,9 +36,9 @@ module Cloudflare
     end
 
     # Workers `env.SEND_EMAIL.send({ to, from, subject, text?, html?, replyTo? })`.
-    # `to`: String, Array (nested), or Hash with `:email` / `'email'` (display `name` on `to`
-    # recipients is not preserved — only the address string is sent). `from` / `reply_to`:
-    # String or `{ email:, name: }`. At least one of `text:` or `html:` is required.
+    # `to`: String, Array (nested), or `{ email:, name?: }`; name is forwarded to Workers as
+    # `{ email, name }` entries when present. `from` / `reply_to`: String or `{ email:, name?: }`.
+    # At least one of `text:` or `html:` is required.
     def send(to:, from:, subject:, text: nil, html: nil, reply_to: nil)
       js = @js
       err_klass = Cloudflare::Email::Error
@@ -81,7 +81,7 @@ module Cloudflare
       obj = `({})`
       `#{obj}.subject = #{subject}`
 
-      # --- to (string | string[]) -----------------------------------------
+      # --- to (string | mixed array per Workers API) ---------------------
       to_js = normalize_to_js(to)
       `#{obj}.to = #{to_js}`
 
@@ -98,16 +98,27 @@ module Cloudflare
       obj
     end
 
-    # Returns a JS array of email strings or a single string (API accepts both).
+    # Returns a JS array: mix of address strings and `{ email, name? }` objects (Workers API shape).
     def normalize_to_js(raw)
-      emails = flatten_recipients(raw)
-      raise Error, 'to is empty' if emails.empty?
+      entries = flatten_recipients(raw)
+      raise Error, 'to is empty' if entries.empty?
 
       arr = `([])`
-      emails.each { |e| `#{arr}.push(#{e})` }
+      entries.each do |e|
+        case e
+        when String
+          `#{arr}.push(#{e})`
+        when Hash
+          js = `({})`
+          `#{js}.email = #{e[:email]}`
+          `#{js}.name = #{e[:name].to_s}` if e[:name] && !e[:name].to_s.strip.empty?
+          `#{arr}.push(#{js})`
+        end
+      end
       arr
     end
 
+    # Returns Ruby strings (bare address) or `{ email:, name: }` when a display name was given.
     def flatten_recipients(raw)
       case raw
       when nil
@@ -117,7 +128,13 @@ module Cloudflare
         s.empty? ? [] : [s]
       when Hash
         em = raw[:email] || raw['email']
-        em.nil? ? [] : [em.to_s.strip].reject(&:empty?)
+        return [] if em.nil? || em.to_s.strip.empty?
+        nm = raw[:name] || raw['name']
+        if nm.nil? || nm.to_s.strip.empty?
+          [em.to_s.strip]
+        else
+          [{ email: em.to_s.strip, name: nm.to_s }]
+        end
       when Array
         raw.flat_map { |x| flatten_recipients(x) }
       else

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers/email.rb
@@ -36,8 +36,9 @@ module Cloudflare
     end
 
     # Workers `env.SEND_EMAIL.send({ to, from, subject, text?, html?, replyTo? })`.
-    # `to` / `from` / `reply_to` accept String, Hash ({ email:, name: }), or Arrays.
-    # At least one of `text:` or `html:` is required.
+    # `to`: String, Array (nested), or Hash with `:email` / `'email'` (display `name` on `to`
+    # recipients is not preserved — only the address string is sent). `from` / `reply_to`:
+    # String or `{ email:, name: }`. At least one of `text:` or `html:` is required.
     def send(to:, from:, subject:, text: nil, html: nil, reply_to: nil)
       js = @js
       err_klass = Cloudflare::Email::Error
@@ -51,18 +52,20 @@ module Cloudflare
 
       payload = build_send_payload(to: to, from: from, subject: subject.to_s, text: text, html: html, reply_to: reply_to)
 
-      `(async function(binding, payload, Kernel, Err) {
+      cf = Cloudflare
+      `(async function(binding, payload, Kernel, Err, cf) {
         try {
           var r = await binding.send(payload);
           if (r == null) return nil;
           var mid = r.messageId != null ? String(r.messageId) : '';
-          return { message_id: mid };
+          var o = {}; o['message_id'] = mid;
+          return cf.$js_object_to_hash(o);
         } catch (e) {
           var code = (e && e.code != null) ? String(e.code) : '';
           var msg = (e && e.message) ? String(e.message) : String(e);
           Kernel.$raise(Err.$new(msg, Opal.hash({ code: code })));
         }
-      })(#{js}, #{payload}, #{Kernel}, #{err_klass})`
+      })(#{js}, #{payload}, #{Kernel}, #{err_klass}, #{cf})`
     end
 
     private

--- a/gems/cloudflare-workers-runtime/lib/cloudflare_workers/version.rb
+++ b/gems/cloudflare-workers-runtime/lib/cloudflare_workers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CloudflareWorkers
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/gems/cloudflare-workers-runtime/lib/opal_patches.rb
+++ b/gems/cloudflare-workers-runtime/lib/opal_patches.rb
@@ -250,10 +250,16 @@ module ::URI
   # them. Back them with CGI so that Rack's query-string parser works for
   # any request with a body / query (Sinatra's `request.body.read` path
   # eventually walks through this code).
-  unless respond_to?(:decode_www_form_component)
-    def self.decode_www_form_component(str, _enc = nil)
-      CGI.unescape(str.to_s)
-    end
+  #
+  # IMPORTANT (Opal): CGI.unescape maps to JS **decodeURI**, which does NOT
+  # decode `%2F` (`/`). RFC 3986 decodeURI reserves those escapes; Rack form
+  # bodies need **decodeURIComponent** semantics (same as CGI.unescapeURIComponent).
+  # Without this, HTML like `</h1>` survives as literal `<%2Fh1>` in params.
+  def self.decode_www_form_component(str, _enc = nil)
+    s = str.to_s.tr('+', ' ')
+    CGI.unescapeURIComponent(s)
+  rescue ::Exception
+    str.to_s
   end
 
   unless respond_to?(:encode_www_form_component)

--- a/gems/cloudflare-workers-runtime/runtime/worker_module.mjs
+++ b/gems/cloudflare-workers-runtime/runtime/worker_module.mjs
@@ -13,6 +13,46 @@ function rackDispatch() {
   return fn || globalThis.__HOMURABI_RACK_DISPATCH__;
 }
 
+/** Phase 17 — Workers `env.SEND_EMAIL` を Rack 構築より前に global に載せ、Miniflare でも Ruby が同じバインディングを拾えるようにする。 */
+function ensureOpalWorkersEmailBinding(env) {
+  const ow = (globalThis.__OPAL_WORKERS__ ||= {});
+  if (env && env.SEND_EMAIL) {
+    ow.sendEmailBinding = env.SEND_EMAIL;
+  }
+}
+
+/**
+ * Miniflare の entry.worker は `/cdn-cgi/mf/scheduled` だけ先に処理する。
+ * `/cdn-cgi/handler/email` 等はユーザ Worker の fetch に届くため、ここで Rack に渡さず処理する。
+ * （Cloudflare Email Routing — Local Development の受信スタブ向け。Phase 18 で `email()` と接続予定）
+ */
+async function handleCdnCgiBypass(request, env, _ctx) {
+  const url = new URL(request.url);
+  if (url.pathname === "/cdn-cgi/handler/email") {
+    if (request.method === "POST") {
+      try {
+        globalThis.console.log(
+          "[homurabi] POST /cdn-cgi/handler/email — bypass Rack (Email Routing local-dev stub path)",
+        );
+      } catch (_e) {}
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          bypass: "rack",
+          pathname: url.pathname,
+          note: "homurabi worker_module forwards /cdn-cgi away from Sinatra. Full inbound handling: Phase 18 (export email()).",
+        }),
+        { status: 200, headers: { "content-type": "application/json; charset=utf-8" } },
+      );
+    }
+    return new Response("Method Not Allowed", { status: 405 });
+  }
+  if (env.ASSETS && typeof env.ASSETS.fetch === "function") {
+    return env.ASSETS.fetch(request);
+  }
+  return new Response("not handled", { status: 404, headers: { "content-type": "text/plain; charset=utf-8" } });
+}
+
 function scheduledDispatch() {
   const ow = globalThis.__OPAL_WORKERS__;
   const fn = ow && typeof ow.scheduled === "function" ? ow.scheduled : undefined;
@@ -101,6 +141,18 @@ async function readBodyTextForRubyDispatcher(request) {
 
 export default {
   async fetch(request, env, ctx) {
+    ensureOpalWorkersEmailBinding(env);
+
+    let reqUrl;
+    try {
+      reqUrl = new URL(request.url);
+    } catch (_e) {
+      reqUrl = { pathname: "/" };
+    }
+    if (reqUrl.pathname.startsWith("/cdn-cgi/")) {
+      return handleCdnCgiBypass(request, env, ctx);
+    }
+
     const dispatch = rackDispatch();
     if (typeof dispatch !== "function") {
       return new Response(

--- a/gems/cloudflare-workers-runtime/templates/wrangler.toml.example
+++ b/gems/cloudflare-workers-runtime/templates/wrangler.toml.example
@@ -1,0 +1,8 @@
+# Minimal Consumer wrangler.toml — paste into your Worker project.
+# Phase 17: uncomment to enable Cloudflare Email Service outbound sending.
+
+# [[send_email]]
+# name = "SEND_EMAIL"
+
+# [vars]
+# HOMURABI_MAIL_FROM = "noreply@your-verified-domain.example"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "build:opal": "bundle exec cloudflare-workers-build",
     "build": "ruby bin/generate-docs-search-index && bundle exec cloudflare-workers-build",
     "dev": "npm run build && wrangler dev --port 8787 --ip 127.0.0.1",
+    "dev:remote": "npm run build && wrangler dev --remote --port 8787 --ip 127.0.0.1",
+    "preflight": "npm test && npm run build",
     "dev:dlq": "npm run build && wrangler dev --env dlq-demo --port 8787 --ip 127.0.0.1",
     "d1:init": "bin/init-local-d1",
     "test:workers": "bin/test-on-workers",

--- a/public/docs-search-index.json
+++ b/public/docs-search-index.json
@@ -153,5 +153,35 @@
     "t": "Architecture — 依存関係（Mermaid）",
     "h": "/docs/architecture#diagram",
     "k": "Architecture 依存関係（Mermaid）"
+  },
+  {
+    "t": "Email Service — 概要",
+    "h": "/docs/email#overview",
+    "k": "Email Service 概要"
+  },
+  {
+    "t": "Email Service — domain onboarding",
+    "h": "/docs/email#setup",
+    "k": "Email Service domain onboarding"
+  },
+  {
+    "t": "Email Service — Cloudflare::Email",
+    "h": "/docs/email#wrapper",
+    "k": "Email Service Cloudflare::Email"
+  },
+  {
+    "t": "Email Service — できること / できないこと",
+    "h": "/docs/email#matrix",
+    "k": "Email Service できること / できないこと"
+  },
+  {
+    "t": "Email Service — セルフホストデモ",
+    "h": "/docs/email#debug",
+    "k": "Email Service セルフホストデモ"
+  },
+  {
+    "t": "Email Service — 公式リンク",
+    "h": "/docs/email#links",
+    "k": "Email Service 公式リンク"
   }
 ]

--- a/tools/split_routes_to_fragments.rb
+++ b/tools/split_routes_to_fragments.rb
@@ -47,6 +47,12 @@ def trim_route_chunk(chunk)
   chunk[0..last_i]
 end
 
+# `canonical_all.rb` lines are indented with 2 spaces (as if inside `class App`). Fragment
+# files are read alone, so strip that common leading 2 spaces for a top-level look.
+def dedent_route_chunk_lines(chunk)
+  chunk.map { |line| line.sub(/\A  /, '') }
+end
+
 def route_starts?(line)
   line =~ ROUTE_HEAD
 end
@@ -92,7 +98,7 @@ route_chunks.each_with_index do |chunk, idx|
   fname = format('route_%03d.rb', idx + 1)
   body = +await_line + "\n# frozen_string_literal: true\n"
   body << "# Route fragment #{idx + 1} — #{cat} #{path}\n"
-  body << chunk.join
+  body << dedent_route_chunk_lines(chunk).join
   File.write(File.join(FRAG, fname), body)
 end
 

--- a/views/_docs_nav.erb
+++ b/views/_docs_nav.erb
@@ -9,6 +9,7 @@
   <a href="/docs/sinatra" class="<%= p == 'sinatra' ? 'docs-nav-active' : '' %>">sinatra-cloudflare-workers</a>
   <a href="/docs/sequel-d1" class="<%= p == 'sequel-d1' ? 'docs-nav-active' : '' %>">sequel-d1</a>
   <a href="/docs/runtime" class="<%= p == 'runtime' ? 'docs-nav-active' : '' %>">cloudflare-workers-runtime</a>
+  <a href="/docs/email" class="<%= p == 'email' ? 'docs-nav-active' : '' %>">Email Service</a>
   <h3>Architecture</h3>
   <a href="/docs/architecture" class="<%= p == 'architecture' ? 'docs-nav-active' : '' %>">3 gem 構造</a>
 </aside>

--- a/views/debug_mail.erb
+++ b/views/debug_mail.erb
@@ -31,8 +31,12 @@
       <input id="subject" name="subject" type="text" value="<%= ERB::Util.html_escape(@form_subject.to_s) %>" style="width:100%;box-sizing:border-box;">
     </p>
     <p>
-      <label for="text">本文（空ならデフォルト英文）</label><br>
+      <label for="text">Plain text（任意。<code>html</code> のみ指定時は省略可）</label><br>
       <textarea id="text" name="text" rows="8" style="width:100%;box-sizing:border-box;"><%= ERB::Util.html_escape(@form_text.to_s) %></textarea>
+    </p>
+    <p>
+      <label for="html">HTML body（任意。<code>text:</code> と併用可）</label><br>
+      <textarea id="html" name="html" rows="8" placeholder="<p>HTML body…</p>" style="width:100%;box-sizing:border-box;"><%= ERB::Util.html_escape(@form_html.to_s) %></textarea>
     </p>
     <p><button type="submit">送信</button></p>
   </form>

--- a/views/debug_mail.erb
+++ b/views/debug_mail.erb
@@ -3,36 +3,36 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title><%= @title %></title>
+  <title><%= Rack::Utils.escape_html(@title.to_s) %></title>
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-  <h1><%= @title %></h1>
+  <h1><%= Rack::Utils.escape_html(@title.to_s) %></h1>
   <p>Cloudflare Email Service（<code>SEND_EMAIL</code>）経由の送信テスト。from は <code>HOMURABI_MAIL_FROM</code>（verified）、ローカルでは認証免除。</p>
   <% if @mail_from && !@mail_from.empty? %>
-    <p><strong>現在の From（vars）</strong>: <code><%= @mail_from %></code></p>
+    <p><strong>現在の From（vars）</strong>: <code><%= Rack::Utils.escape_html(@mail_from.to_s) %></code></p>
   <% else %>
     <p><strong>HOMURABI_MAIL_FROM</strong>: 未設定（ドメイン onboarding と wrangler vars が必要）</p>
   <% end %>
   <% if @error %>
-    <p role="alert" style="color:#b91c1c;"><strong>エラー:</strong> <%= @error %></p>
+    <p role="alert" style="color:#b91c1c;"><strong>エラー:</strong> <%= Rack::Utils.escape_html(@error.to_s) %></p>
   <% end %>
   <% if @success_json %>
     <h2>送信結果（JSON）</h2>
-    <pre style="white-space:pre-wrap;background:#f3f4f6;padding:1rem;border-radius:6px;"><%= @success_json %></pre>
+    <pre style="white-space:pre-wrap;background:#f3f4f6;padding:1rem;border-radius:6px;"><%= Rack::Utils.escape_html(@success_json.to_s) %></pre>
   <% end %>
   <form method="post" action="/debug/mail" style="max-width:36rem;">
     <p>
       <label for="to">To</label><br>
-      <input id="to" name="to" type="email" value="<%= @form_to %>" style="width:100%;box-sizing:border-box;" required>
+      <input id="to" name="to" type="email" value="<%= Rack::Utils.escape_html(@form_to.to_s) %>" style="width:100%;box-sizing:border-box;" required>
     </p>
     <p>
       <label for="subject">Subject（空なら自動で Phase 17 テスト件名）</label><br>
-      <input id="subject" name="subject" type="text" value="<%= @form_subject %>" style="width:100%;box-sizing:border-box;">
+      <input id="subject" name="subject" type="text" value="<%= Rack::Utils.escape_html(@form_subject.to_s) %>" style="width:100%;box-sizing:border-box;">
     </p>
     <p>
       <label for="text">本文（空ならデフォルト英文）</label><br>
-      <textarea id="text" name="text" rows="8" style="width:100%;box-sizing:border-box;"><%= @form_text %></textarea>
+      <textarea id="text" name="text" rows="8" style="width:100%;box-sizing:border-box;"><%= Rack::Utils.escape_html(@form_text.to_s) %></textarea>
     </p>
     <p><button type="submit">送信</button></p>
   </form>

--- a/views/debug_mail.erb
+++ b/views/debug_mail.erb
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title><%= @title %></title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <h1><%= @title %></h1>
+  <p>Cloudflare Email Service（<code>SEND_EMAIL</code>）経由の送信テスト。from は <code>HOMURABI_MAIL_FROM</code>（verified）、ローカルでは認証免除。</p>
+  <% if @mail_from && !@mail_from.empty? %>
+    <p><strong>現在の From（vars）</strong>: <code><%= @mail_from %></code></p>
+  <% else %>
+    <p><strong>HOMURABI_MAIL_FROM</strong>: 未設定（ドメイン onboarding と wrangler vars が必要）</p>
+  <% end %>
+  <% if @error %>
+    <p role="alert" style="color:#b91c1c;"><strong>エラー:</strong> <%= @error %></p>
+  <% end %>
+  <% if @success_json %>
+    <h2>送信結果（JSON）</h2>
+    <pre style="white-space:pre-wrap;background:#f3f4f6;padding:1rem;border-radius:6px;"><%= @success_json %></pre>
+  <% end %>
+  <form method="post" action="/debug/mail" style="max-width:36rem;">
+    <p>
+      <label for="to">To</label><br>
+      <input id="to" name="to" type="email" value="<%= @form_to %>" style="width:100%;box-sizing:border-box;" required>
+    </p>
+    <p>
+      <label for="subject">Subject（空なら自動で Phase 17 テスト件名）</label><br>
+      <input id="subject" name="subject" type="text" value="<%= @form_subject %>" style="width:100%;box-sizing:border-box;">
+    </p>
+    <p>
+      <label for="text">本文（空ならデフォルト英文）</label><br>
+      <textarea id="text" name="text" rows="8" style="width:100%;box-sizing:border-box;"><%= @form_text %></textarea>
+    </p>
+    <p><button type="submit">送信</button></p>
+  </form>
+  <p><a href="/docs/email">ドキュメント</a> · <a href="/">トップ</a></p>
+</body>
+</html>

--- a/views/debug_mail.erb
+++ b/views/debug_mail.erb
@@ -14,29 +14,31 @@
   <% else %>
     <p><strong>HOMURABI_MAIL_FROM</strong>: 未設定（ドメイン onboarding と wrangler vars が必要）</p>
   <% end %>
-  <% if @error %>
-    <p role="alert" style="color:#b91c1c;"><strong>エラー:</strong> <%= ERB::Util.html_escape(@error.to_s) %></p>
-  <% end %>
-  <% if @success_json %>
+  <% if @result && @result[:error] %>
+    <p role="alert" style="color:#b91c1c;"><strong>エラー:</strong> <%= ERB::Util.html_escape(@result[:error].to_s) %></p>
+  <% elsif @result && @result[:raw_json] %>
     <h2>送信結果（JSON）</h2>
-    <pre style="white-space:pre-wrap;background:#f3f4f6;padding:1rem;border-radius:6px;"><%= ERB::Util.html_escape(@success_json.to_s) %></pre>
+    <pre style="white-space:pre-wrap;background:#f3f4f6;padding:1rem;border-radius:6px;"><%= ERB::Util.html_escape(@result[:raw_json].to_s) %></pre>
+    <% if @result[:warning] %>
+      <p role="status" style="color:#b45309;"><strong>注意:</strong> <%= ERB::Util.html_escape(@result[:warning].to_s) %></p>
+    <% end %>
   <% end %>
   <form method="post" action="/debug/mail" style="max-width:36rem;">
     <p>
       <label for="to">To</label><br>
-      <input id="to" name="to" type="email" value="<%= ERB::Util.html_escape(@form_to.to_s) %>" style="width:100%;box-sizing:border-box;" required>
+      <input id="to" name="to" type="email" value="<%= ERB::Util.html_escape(@form[:to].to_s) %>" style="width:100%;box-sizing:border-box;" required>
     </p>
     <p>
       <label for="subject">Subject（空なら自動で Phase 17 テスト件名）</label><br>
-      <input id="subject" name="subject" type="text" value="<%= ERB::Util.html_escape(@form_subject.to_s) %>" style="width:100%;box-sizing:border-box;">
+      <input id="subject" name="subject" type="text" value="<%= ERB::Util.html_escape(@form[:subject].to_s) %>" style="width:100%;box-sizing:border-box;">
     </p>
     <p>
       <label for="text">Plain text（任意。<code>html</code> のみ指定時は省略可）</label><br>
-      <textarea id="text" name="text" rows="8" style="width:100%;box-sizing:border-box;"><%= ERB::Util.html_escape(@form_text.to_s) %></textarea>
+      <textarea id="text" name="text" rows="8" style="width:100%;box-sizing:border-box;"><%= ERB::Util.html_escape(@form[:text].to_s) %></textarea>
     </p>
     <p>
       <label for="html">HTML body（任意。<code>text:</code> と併用可）</label><br>
-      <textarea id="html" name="html" rows="8" placeholder="<p>HTML body…</p>" style="width:100%;box-sizing:border-box;"><%= ERB::Util.html_escape(@form_html.to_s) %></textarea>
+      <textarea id="html" name="html" rows="8" placeholder="<p>HTML body…</p>" style="width:100%;box-sizing:border-box;"><%= ERB::Util.html_escape(@form[:html].to_s) %></textarea>
     </p>
     <p><button type="submit">送信</button></p>
   </form>

--- a/views/debug_mail.erb
+++ b/views/debug_mail.erb
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title><%= Rack::Utils.escape_html(@title.to_s) %></title>
+  <title><%= ERB::Util.html_escape(@title.to_s) %></title>
   <link rel="stylesheet" href="/style.css">
 </head>
 <body>
-  <h1><%= Rack::Utils.escape_html(@title.to_s) %></h1>
+  <h1><%= ERB::Util.html_escape(@title.to_s) %></h1>
   <p>Cloudflare Email Service（<code>SEND_EMAIL</code>）経由の送信テスト。from は <code>HOMURABI_MAIL_FROM</code>（verified）、ローカルでは認証免除。</p>
   <% if @mail_from && !@mail_from.empty? %>
-    <p><strong>現在の From（vars）</strong>: <code><%= Rack::Utils.escape_html(@mail_from.to_s) %></code></p>
+    <p><strong>現在の From（vars）</strong>: <code><%= ERB::Util.html_escape(@mail_from.to_s) %></code></p>
   <% else %>
     <p><strong>HOMURABI_MAIL_FROM</strong>: 未設定（ドメイン onboarding と wrangler vars が必要）</p>
   <% end %>
@@ -24,15 +24,15 @@
   <form method="post" action="/debug/mail" style="max-width:36rem;">
     <p>
       <label for="to">To</label><br>
-      <input id="to" name="to" type="email" value="<%= Rack::Utils.escape_html(@form_to.to_s) %>" style="width:100%;box-sizing:border-box;" required>
+      <input id="to" name="to" type="email" value="<%= ERB::Util.html_escape(@form_to.to_s) %>" style="width:100%;box-sizing:border-box;" required>
     </p>
     <p>
       <label for="subject">Subject（空なら自動で Phase 17 テスト件名）</label><br>
-      <input id="subject" name="subject" type="text" value="<%= Rack::Utils.escape_html(@form_subject.to_s) %>" style="width:100%;box-sizing:border-box;">
+      <input id="subject" name="subject" type="text" value="<%= ERB::Util.html_escape(@form_subject.to_s) %>" style="width:100%;box-sizing:border-box;">
     </p>
     <p>
       <label for="text">本文（空ならデフォルト英文）</label><br>
-      <textarea id="text" name="text" rows="8" style="width:100%;box-sizing:border-box;"><%= Rack::Utils.escape_html(@form_text.to_s) %></textarea>
+      <textarea id="text" name="text" rows="8" style="width:100%;box-sizing:border-box;"><%= ERB::Util.html_escape(@form_text.to_s) %></textarea>
     </p>
     <p><button type="submit">送信</button></p>
   </form>

--- a/views/debug_mail.erb
+++ b/views/debug_mail.erb
@@ -15,11 +15,11 @@
     <p><strong>HOMURABI_MAIL_FROM</strong>: 未設定（ドメイン onboarding と wrangler vars が必要）</p>
   <% end %>
   <% if @error %>
-    <p role="alert" style="color:#b91c1c;"><strong>エラー:</strong> <%= Rack::Utils.escape_html(@error.to_s) %></p>
+    <p role="alert" style="color:#b91c1c;"><strong>エラー:</strong> <%= ERB::Util.html_escape(@error.to_s) %></p>
   <% end %>
   <% if @success_json %>
     <h2>送信結果（JSON）</h2>
-    <pre style="white-space:pre-wrap;background:#f3f4f6;padding:1rem;border-radius:6px;"><%= Rack::Utils.escape_html(@success_json.to_s) %></pre>
+    <pre style="white-space:pre-wrap;background:#f3f4f6;padding:1rem;border-radius:6px;"><%= ERB::Util.html_escape(@success_json.to_s) %></pre>
   <% end %>
   <form method="post" action="/debug/mail" style="max-width:36rem;">
     <p>

--- a/views/docs_email.erb
+++ b/views/docs_email.erb
@@ -24,8 +24,8 @@ HOMURABI_MAIL_FROM = "noreply@example.com"
 </code></pre>
 
 <h2 id="wrapper">Cloudflare::Email</h2>
-<p><code>gems/cloudflare-workers-runtime</code> が Rack 環境に <code>env['cloudflare.SEND_EMAIL']</code> を載せます。</p>
-<pre><code>mail = env['cloudflare.SEND_EMAIL']
+<p><strong>送信バインディングは Worker の <code>env.SEND_EMAIL</code> が正</strong>です。<code>worker_module.mjs</code> の <code>fetch</code> 先頭で <code>globalThis.__OPAL_WORKERS__.sendEmailBinding</code> にコピーしたうえで、Rack 側は <code>env['cloudflare.SEND_EMAIL']</code>（<code>Cloudflare::Email</code> ラッパー）として参照します。D1 / Queue などが <code>cloudflare.env</code> 経由で触るパターンとは別に、Email はこの明示注入経路が主軸です（Miniflare でも同じ JS オブジェクトを拾えるようにするため）。</p>
+<pre><code>mail = send_email # => env['cloudflare.SEND_EMAIL']（内部は env.SEND_EMAIL と同一バインディング）
 mail.send(
   to: 'you@example.com',
   from: ENV_STYLE_FROM, # 実際は vars の HOMURABI_MAIL_FROM を参照

--- a/views/docs_email.erb
+++ b/views/docs_email.erb
@@ -30,7 +30,8 @@ mail.send(
   to: 'you@example.com',
   from: ENV_STYLE_FROM, # 実際は vars の HOMURABI_MAIL_FROM を参照
   subject: 'Hello',
-  text: 'Plain text body'
+  text: 'Plain text body',
+  html: '&lt;p&gt;Optional rich body&lt;/p&gt;' # 省略可／text と併用可（どちらか必須）
 ).__await__
 </code></pre>
 <p>アプリ側ではヘルパー <code>send_email</code> と <code>homurabi_mail_from</code> を利用できます。</p>

--- a/views/docs_email.erb
+++ b/views/docs_email.erb
@@ -4,7 +4,7 @@
 <h2 id="overview">概要</h2>
 <ul>
   <li>Workers の binding だけで送信でき、別途 API キーをコードに埋め込む必要はありません。</li>
-  <li>このサイトではテスト用に <a href="/debug/mail"><code>/debug/mail</code></a> を用意しています（本番ではログインユーザー <code>kazuph</code> のみ）。</li>
+  <li>このサイトではテスト用に <a href="/debug/mail"><code>/debug/mail</code></a> を用意しています（本番では認可されたセッションのみ）。</li>
 </ul>
 
 <h2 id="setup">domain onboarding</h2>

--- a/views/docs_email.erb
+++ b/views/docs_email.erb
@@ -1,0 +1,58 @@
+<h1>Cloudflare Email Service（送信）</h1>
+<p>Agents Week 2026 で public beta の Email Sending を、homurabi では <code>SEND_EMAIL</code> バインディングと Ruby ラッパー <code>Cloudflare::Email</code> から利用します。</p>
+
+<h2 id="overview">概要</h2>
+<ul>
+  <li>Workers の binding だけで送信でき、別途 API キーをコードに埋め込む必要はありません。</li>
+  <li>このサイトではテスト用に <a href="/debug/mail"><code>/debug/mail</code></a> を用意しています（本番ではログインユーザー <code>kazuph</code> のみ）。</li>
+</ul>
+
+<h2 id="setup">domain onboarding</h2>
+<ol>
+  <li>Cloudflare Dashboard → Email Sending → Onboard Domain で所有ドメインを選択。</li>
+  <li>DNS（SPF / DKIM / DMARC / bounce 用 MX）が自動提案されるので承認・反映を待つ。</li>
+  <li>検証済みの送信元アドレスを決め、<code>wrangler.toml</code> の <code>[vars] HOMURABI_MAIL_FROM</code> に設定する。</li>
+</ol>
+<p>未 onboarding のまま送ると <code>E_SENDER_NOT_VERIFIED</code> や <code>E_SENDER_DOMAIN_NOT_AVAILABLE</code> などが返ります。</p>
+
+<pre><code># wrangler.toml（抜粋）
+[[send_email]]
+name = "SEND_EMAIL"
+
+[vars]
+HOMURABI_MAIL_FROM = "noreply@example.com"
+</code></pre>
+
+<h2 id="wrapper">Cloudflare::Email</h2>
+<p><code>gems/cloudflare-workers-runtime</code> が Rack 環境に <code>env['cloudflare.SEND_EMAIL']</code> を載せます。</p>
+<pre><code>mail = env['cloudflare.SEND_EMAIL']
+mail.send(
+  to: 'you@example.com',
+  from: ENV_STYLE_FROM, # 実際は vars の HOMURABI_MAIL_FROM を参照
+  subject: 'Hello',
+  text: 'Plain text body'
+).__await__
+</code></pre>
+<p>アプリ側ではヘルパー <code>send_email</code> と <code>homurabi_mail_from</code> を利用できます。</p>
+
+<h2 id="matrix">できること / できないこと</h2>
+<table>
+  <thead><tr><th></th><th>できること</th><th>できないこと</th></tr></thead>
+  <tbody>
+    <tr><td>送信</td><td>トランザクショナルメール（Workers binding 経由）</td><td>マーケティング向けの購読管理・テンプレート基盤は対象外</td></tr>
+    <tr><td>宛先</td><td>仕様上は任意の宛先（Rate / アカウント制限は別途）</td><td>インバウンド受信は <a href="https://developers.cloudflare.com/email-service/">別 API</a></td></tr>
+    <tr><td>ローカル</td><td><code>wrangler dev</code>（既定はシミュレーション、<code>remote: true</code> で実送信も可）</td><td>このリポジトリではデフォルト運用のみ記載</td></tr>
+    <tr><td>料金</td><td>Cloudflare の Email Service / Workers 課金ポリシーに従う</td><td>無料枠のみでの無制限は保証されない</td></tr>
+  </tbody>
+</table>
+
+<h2 id="debug">セルフホストデモ</h2>
+<p>認証付きの簡易フォーム: <a href="/debug/mail">/debug/mail</a></p>
+
+<h2 id="links">公式リンク</h2>
+<ul>
+  <li><a href="https://developers.cloudflare.com/email-service/get-started/send-emails/">Get Started — Send emails</a></li>
+  <li><a href="https://developers.cloudflare.com/email-service/api/send-emails/workers-api/">Workers API（send）</a></li>
+  <li><a href="https://developers.cloudflare.com/email-service/">Email Service トップ</a></li>
+  <li><a href="https://blog.cloudflare.com/email-for-agents/">ブログ: Email for Agents</a></li>
+</ul>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -37,6 +37,11 @@ bucket_name = "homurabi-bucket"
 [ai]
 binding = "AI"
 
+# Phase 17 — Cloudflare Email Service (Agents Week 2026 public beta).
+# Routes use `env['cloudflare.SEND_EMAIL']` → Cloudflare::Email wrapping `env.SEND_EMAIL`.
+[[send_email]]
+name = "SEND_EMAIL"
+
 # Phase 7: gating for the educational crypto routes (`/test/crypto`,
 # `/demo/crypto`). Default OFF — those routes generate fresh RSA keys
 # and run PBKDF2 per request, so leaving them open in production is a
@@ -70,6 +75,8 @@ HOMURABI_ENABLE_SCHEDULED_DEMOS = "0"
 # external JSON API (ipify) and writes to R2 under phase11a/, so we
 # keep the pattern: default OFF, flip to "1" only in dev.
 HOMURABI_ENABLE_FOUNDATIONS_DEMOS = "0"
+# Phase 17 — verified From address after Email Service domain onboarding (`HOMURABI_MAIL_FROM`).
+HOMURABI_MAIL_FROM = ""
 
 # Phase 9 — Cloudflare Workers Cron Triggers.
 #
@@ -176,6 +183,7 @@ HOMURABI_ENABLE_CRYPTO_DEMOS = "0"
 HOMURABI_ENABLE_AI_DEMOS = "0"
 HOMURABI_ENABLE_BINDING_DEMOS = "0"
 HOMURABI_ENABLE_SCHEDULED_DEMOS = "0"
+HOMURABI_MAIL_FROM = ""
 
 [[env.dlq-demo.d1_databases]]
 binding = "DB"
@@ -192,6 +200,9 @@ bucket_name = "homurabi-bucket"
 
 [env.dlq-demo.ai]
 binding = "AI"
+
+[[env.dlq-demo.send_email]]
+name = "SEND_EMAIL"
 
 [[env.dlq-demo.durable_objects.bindings]]
 name       = "COUNTER"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,6 +13,7 @@ compatibility_flags = ["nodejs_compat"]
 binding = "DB"
 database_name = "homurabi-db"
 database_id = "3a59c955-198e-478f-8f11-71d5f3eb7600"
+preview_database_id = "6642a8ca-c5d0-4277-9755-3bcee6147c11"
 # Phase 13 follow-up: Sequel migrations compiled by `bin/homurabi-migrate`
 # (wrapper → `cloudflare-workers-migrate`) into `.sql` files under the same path. Point
 # `wrangler d1 migrations apply` at the same directory so both tools
@@ -22,10 +23,13 @@ migrations_dir = "db/migrations"
 [[kv_namespaces]]
 binding = "KV"
 id = "64ee32f1c6c64f85af9591e827da7462"
+# Remote/preview `wrangler dev` requires a separate preview namespace (production id above unchanged).
+preview_id = "4a478ce244b5493d857b5f715ed8acf5"
 
 [[r2_buckets]]
 binding = "BUCKET"
 bucket_name = "homurabi-bucket"
+preview_bucket_name = "homurabi-r2-remote-preview"
 
 # Phase 10: Workers AI binding. Routes reach this from Ruby as
 # `env['cloudflare.AI']` and pass it to `Cloudflare::AI.run(model, …)`.
@@ -75,8 +79,8 @@ HOMURABI_ENABLE_SCHEDULED_DEMOS = "0"
 # external JSON API (ipify) and writes to R2 under phase11a/, so we
 # keep the pattern: default OFF, flip to "1" only in dev.
 HOMURABI_ENABLE_FOUNDATIONS_DEMOS = "0"
-# Phase 17 — verified From address after Email Service domain onboarding (`HOMURABI_MAIL_FROM`).
-HOMURABI_MAIL_FROM = ""
+# Phase 17 — verified From address (domain kazuph-info.ai-work.uk onboarded 2026-04-21).
+HOMURABI_MAIL_FROM = "noreply@kazuph-info.ai-work.uk"
 
 # Phase 9 — Cloudflare Workers Cron Triggers.
 #
@@ -183,7 +187,7 @@ HOMURABI_ENABLE_CRYPTO_DEMOS = "0"
 HOMURABI_ENABLE_AI_DEMOS = "0"
 HOMURABI_ENABLE_BINDING_DEMOS = "0"
 HOMURABI_ENABLE_SCHEDULED_DEMOS = "0"
-HOMURABI_MAIL_FROM = ""
+HOMURABI_MAIL_FROM = "noreply@kazuph-info.ai-work.uk"
 
 [[env.dlq-demo.d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## 概要
- `Cloudflare::Email` ラッパー + `SEND_EMAIL` バインディング
- `/debug/mail`（本番は `kazuph` セッション必須）、`/docs/email` ドキュメント
- `HOMURABI_MAIL_FROM`（wrangler vars）で verified 送信元

## 本番
- **URL**: https://homurabi.kazu-san.workers.dev
- 初期 `wrangler deploy` 3 回成功、最後の Version ID: `93a266f0-9364-494a-bd1b-e097c5dd28df`（POST ルートの Opal 修正コミット後の再 deploy は承認待ちの可能性あり — 必要なら `mise exec -- npx wrangler deploy` を再実行）

## 部分達成
- **domain onboarding 未実施** — 実メール到達は `REPORT` 参照。`kazu.homma@gmail.com` 宛の本番 POST は `HOMURABI_MAIL_FROM` 設定後に再実施予定。

## エビデンス
- `.artifacts/phase17-email-sending/REPORT.md`（スクリーンショット同梱、リポジトリ外 gitignore）

Made with [Cursor](https://cursor.com)