### PR TITLE
.gitignore: ignore .claude/settings.local.json (per-machine Claude allow-list)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,10 @@ dist/
 # mise local config (per-machine)
 .mise.local.toml
 
+# Claude Code per-machine permission overrides (the project-wide
+# `.claude/settings.json` is tracked; `.claude/settings.local.json`
+# is the per-developer allow-list and should never be committed).
+.claude/settings.local.json
+
 # Local task artifacts (report/evidence, do not version)
 .artifacts/


### PR DESCRIPTION
## Summary

Pin `.claude/settings.local.json` in `.gitignore`. Claude Code splits its config into a tracked `.claude/settings.json` (project-wide) and a per-machine `.claude/settings.local.json` (the developer's local permission allow-list, e.g. `Skill(reporting-and-tmux)`). The local file is rewritten on every session and isn't meant to be shared, so it shouldn't keep showing up as `??` in `git status`.

This is the trailing cleanup behind the `site/` relocation (#35) — that PR left `git status` with a single pre-existing untracked entry, and it turns out it was always going to dirty status until the gitignore was updated.

## Test plan

- [x] `git check-ignore -v .claude/settings.local.json` returns the new rule.
- [x] `git status` is clean on a fresh checkout that has only this one untracked file.
- [x] `.claude/settings.json` (the tracked file) is unaffected — only `settings.local.json` is matched.