### PR TITLE
examples/{sinatra,classic-top-sinatra}: add a friendly GET / route

### DIFF
--- a/examples/classic-top-sinatra/app.rb
+++ b/examples/classic-top-sinatra/app.rb
@@ -3,6 +3,12 @@
 require 'json'
 require 'sinatra'
 
+get '/' do
+  content_type 'text/plain; charset=utf-8'
+  "classic-top-sinatra on Cloudflare Workers\n" \
+    "  GET /dogfood   → JSON proof of classic top-level DSL\n"
+end
+
 get '/dogfood' do
   content_type 'application/json'
   { 'ok' => true, 'mode' => 'classic-top-level' }.to_json

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 require 'sinatra'
 
+get '/' do
+  'sinatra on Cloudflare Workers — try GET /frank-says'
+end
+
 get '/frank-says' do
   'Put this in your pipe & smoke it!'
 end


### PR DESCRIPTION
## Summary

When the four example workers came online under their new hostnames in #38, two of them — `sinatra` and `classic-top-sinatra` — were straight ports of the canonical Sinatra README and intentionally registered only a single demo route (`/frank-says`, `/dogfood`). That meant the bare hostnames (`https://sinatra.kazu-san.workers.dev/`, `https://classic-top-sinatra.kazu-san.workers.dev/`) returned the default Sinatra 404 page (_"Sinatra doesn't know this ditty"_), so anyone clicking the link from a Slack share or pasting the hostname into a browser hit that 404 with no clue where to go next.

This PR adds a tiny `GET '/'` route to each so the hostname itself is self-explanatory; the original demo routes are unchanged.

## Diff

```ruby
# examples/sinatra/app.rb
get '/' do
  'sinatra on Cloudflare Workers — try GET /frank-says'
end

# examples/classic-top-sinatra/app.rb
get '/' do
  content_type 'text/plain; charset=utf-8'
  "classic-top-sinatra on Cloudflare Workers\n" \
    "  GET /dogfood   → JSON proof of classic top-level DSL\n"
end
```

## Live verification (deployed against this branch)

| URL | Before this PR | After this PR |
|---|---|---|
| https://sinatra.kazu-san.workers.dev/             | 404 (Sinatra "ditty" page) | **200** |
| https://sinatra.kazu-san.workers.dev/frank-says   | 200 | 200 |
| https://classic-top-sinatra.kazu-san.workers.dev/         | 404 | **200** |
| https://classic-top-sinatra.kazu-san.workers.dev/dogfood  | 200 | 200 |

The other two newly-deployed examples (`sinatra-with-db`, `sinatra-with-email`) already had `GET '/'` routes in #38 and aren't touched.