### PR TITLE
docs / skills / site views: scrub the retired sinatra/cloudflare_workers naming

### DIFF
--- a/.claude/skills/opal-workers-gem-adoption/SKILL.md
+++ b/.claude/skills/opal-workers-gem-adoption/SKILL.md
@@ -115,7 +115,7 @@ foo_gem/
 | `ruby-jwt` | vendor + patch | 中 (~2.5k 行) | JWT encode/decode |
 | `cgi`, `digest`, `net` (shims) | vendor patches | 小 | stdlib shim |
 | `lib/homura_markdown.rb` | 自作 | 極小 (~200 行) | Markdown → HTML 変換 |
-| `lib/cloudflare_workers/*.rb` | 自作 | 中 | D1/KV/R2/AI/Cache/Queue/DO wrapper |
+| `gems/homura-runtime/lib/homura/runtime/*.rb` | 自作 | 中 | D1/KV/R2/AI/Cache/Queue/DO wrapper（`Cloudflare::*` 名前空間） |
 
 ## 採用判定で迷ったら
 
@@ -141,8 +141,8 @@ foo_gem/
 
 ## Phase 進化でわかった "これはイケる" パターン
 
-- **wrapper 作成パターン** (Phase 3/6/7/9/10/11B): JS binding 側の機能を Ruby から呼べるように backtick x-string で薄く包む。single-line IIFE が安全（multi-line は Promise を silent drop する落とし穴あり — 詳細は `lib/cloudflare_workers/cache.rb#put` のコメント）
+- **wrapper 作成パターン** (Phase 3/6/7/9/10/11B): JS binding 側の機能を Ruby から呼べるように backtick x-string で薄く包む。single-line IIFE が安全（multi-line は Promise を silent drop する落とし穴あり — 詳細は `gems/homura-runtime/lib/homura/runtime/cache.rb#put` のコメント）
 - **dispatcher 登録パターン** (Phase 9/11B): `globalThis.__HOMURA_*_DISPATCH__` に async function を install、`src/worker.mjs` から forward
 - **AOT 変換パターン** (ERB): 実行時 `eval` を回避するため、ビルド時に Ruby コードへ変換
 
-迷ったら既存 wrapper (`lib/cloudflare_workers/*.rb`) と `lib/homura_markdown.rb` を読んで真似る。
+迷ったら既存 wrapper (`gems/homura-runtime/lib/homura/runtime/*.rb`) と `site/lib/homura_markdown.rb` を読んで真似る。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,10 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Ruby syntax check across every gem + example app — fast canary that
-  # catches typos / incomplete modernizations like the recent
-  # `require 'sinatra/cloudflare_workers'` strip. Doesn't run code, just
-  # `ruby -c` parses.
+  # catches typos / incomplete modernizations (the kind that surfaced when
+  # the `sinatra/cloudflare_workers` shim was retired in favour of plain
+  # `require 'sinatra'` / `require 'sinatra/base'`). Doesn't run code,
+  # just `ruby -c` parses.
   # ---------------------------------------------------------------------------
   ruby-syntax:
     name: ruby -c (syntax check)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: gems/homura-runtime
   specs:
-    homura-runtime (0.3.1)
+    homura-runtime (0.3.2)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
 
@@ -17,7 +17,7 @@ PATH
 PATH
   remote: gems/sinatra-homura
   specs:
-    sinatra-homura (0.3.0)
+    sinatra-homura (0.3.1)
       homura-runtime (~> 0.3)
       opal-homura (= 1.8.3.rc1.5)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,22 +11,19 @@
 稼働中のサイト: <https://homura.kazu-san.workers.dev>
 
 ```ruby
-# app/app.rb — そう、これは本当にただの Sinatra だ。
-require 'sinatra/cloudflare_workers'
+# app.rb — そう、これは本当にただの Sinatra だ。
+require 'sinatra'
+require 'sequel'
 
-class App < Sinatra::Base
-  get '/' do
-    'Hello from Ruby, running on Cloudflare Workers.'
-  end
-
-  get '/users' do
-    db = Sequel.connect(adapter: :d1, d1: env['cloudflare.DB'])
-    content_type :json
-    db[:users].order(:id).all.to_json
-  end
+get '/' do
+  'Hello from Ruby, running on Cloudflare Workers.'
 end
 
-run App
+get '/users' do
+  db = Sequel.connect(adapter: :d1, d1: env['cloudflare.DB'])
+  content_type :json
+  db[:users].order(:id).all.to_json
+end
 ```
 
 ```toml
@@ -37,12 +34,15 @@ compatibility_date = "2026-04-27"
 compatibility_flags = ["nodejs_compat"]
 ```
 
-シムも、トランスパイルされた Sinatra もどきも存在しない。継承元の
-`Sinatra::Base` は upstream gem のポートそのものだし、`redirect '/'` は
-Sinatra 純正の `HaltResponse` を raise する。`erb :index, locals: { user: u }`
-もドキュメント通りに locals を解決する。このパイプライン全体は、Ruby
-ユーザーが Ruby を書き続けたまま Cloudflare のエッジに届けられるよう
-にするためだけに存在する。
+シムも、トランスパイルされた Sinatra もどきも存在しない。`require 'sinatra'`
+は canonical な Sinatra ポートをロードする。`redirect '/'` は Sinatra 純正の
+`HaltResponse` を raise する。`erb :index, locals: { user: u }` もドキュメント
+通りに locals を解決する。modular スタイル（`class App < Sinatra::Base` +
+`config.ru` + `run App`）もそのまま動く — 例として
+[`examples/todo/`](examples/todo/) と canonical な
+[`site/`](site/)（homura.kazu-san.workers.dev）を参照。
+このパイプライン全体は、Ruby ユーザーが Ruby を書き続けたまま Cloudflare の
+エッジに届けられるようにするためだけに存在する。
 
 ---
 
@@ -164,15 +164,18 @@ bundle exec rake deploy                            # wrangler deploy
 
    gem 'rake'
    gem 'opal-homura',    '= 1.8.3.rc1.5', require: 'opal'
-   gem 'homura-runtime', '~> 0.2'
-   gem 'sinatra-homura', '~> 0.2'
-   gem 'sequel-d1',      '~> 0.2'   # D1 / Sequel を使う場合のみ
+   gem 'homura-runtime', '~> 0.3'
+   gem 'sinatra-homura', '~> 0.3'
+   gem 'sequel-d1',      '~> 0.3'   # D1 / Sequel を使う場合のみ
    ```
 
-2. **アプリコードを `app/` 配下に移す**（`app/app.rb` が慣習的な
-   エントリポイント）。ルーティングはそのままで、`require 'sinatra'` を
-   `require 'sinatra/cloudflare_workers'` に置き換える。`Sinatra::Base`
-   をサブクラス化する。
+2. **Sinatra アプリは書いたままでよい。** classic スタイル
+   （`require 'sinatra'` + トップレベルの `get '/' do ... end`）も
+   modular スタイル（`require 'sinatra/base'` + `class App < Sinatra::Base`
+   + `config.ru` で `run App`）もどちらも upstream のドキュメント通りに
+   動く。`require` を Cloudflare 専用のものに差し替える必要は **ない** —
+   sinatra-homura が標準の Sinatra エントリポイントの上で Workers ランタイム
+   を自動的に配線する。
 
 3. **`wrangler.toml` を追加** し、`main` を `build/worker.entrypoint.mjs` に
    向け、必要な binding（D1 / KV / R2 / AI / Queue）を宣言する。

--- a/README.md
+++ b/README.md
@@ -9,22 +9,19 @@
 Live site: <https://homura.kazu-san.workers.dev>
 
 ```ruby
-# app/app.rb — yes, it really is plain Sinatra.
-require 'sinatra/cloudflare_workers'
+# app.rb — yes, it really is plain Sinatra.
+require 'sinatra'
+require 'sequel'
 
-class App < Sinatra::Base
-  get '/' do
-    'Hello from Ruby, running on Cloudflare Workers.'
-  end
-
-  get '/users' do
-    db = Sequel.connect(adapter: :d1, d1: env['cloudflare.DB'])
-    content_type :json
-    db[:users].order(:id).all.to_json
-  end
+get '/' do
+  'Hello from Ruby, running on Cloudflare Workers.'
 end
 
-run App
+get '/users' do
+  db = Sequel.connect(adapter: :d1, d1: env['cloudflare.DB'])
+  content_type :json
+  db[:users].order(:id).all.to_json
+end
 ```
 
 ```toml
@@ -35,11 +32,15 @@ compatibility_date = "2026-04-27"
 compatibility_flags = ["nodejs_compat"]
 ```
 
-There is no shim, no transpiled Sinatra-lookalike. The `Sinatra::Base` you
-inherit from is a port of the upstream gem; `redirect '/'` raises Sinatra's
-own `HaltResponse`; `erb :index, locals: { user: u }` resolves locals the
-way the docs say it does. The whole pipeline exists so Ruby people can keep
-writing Ruby and ship it to the Cloudflare edge.
+There is no shim, no transpiled Sinatra-lookalike. `require 'sinatra'`
+loads the canonical Sinatra port; `redirect '/'` raises Sinatra's own
+`HaltResponse`; `erb :index, locals: { user: u }` resolves locals the way
+the docs say it does. Modular apps use the same `class App < Sinatra::Base`
++ `config.ru` + `run App` shape upstream documents — see
+[`examples/todo/`](examples/todo/) and the canonical
+[`site/`](site/) homura.kazu-san.workers.dev source. The whole pipeline
+exists so Ruby people can keep writing Ruby and ship it to the
+Cloudflare edge.
 
 ---
 
@@ -158,14 +159,18 @@ If you already have Ruby and want to ship it to Workers:
 
    gem 'rake'
    gem 'opal-homura',    '= 1.8.3.rc1.5', require: 'opal'
-   gem 'homura-runtime', '~> 0.2'
-   gem 'sinatra-homura', '~> 0.2'
-   gem 'sequel-d1',      '~> 0.2'   # only if you want D1 / Sequel
+   gem 'homura-runtime', '~> 0.3'
+   gem 'sinatra-homura', '~> 0.3'
+   gem 'sequel-d1',      '~> 0.3'   # only if you want D1 / Sequel
    ```
 
-2. **Move app code under `app/`** (`app/app.rb` is the conventional
-   entrypoint). Keep your routes; replace `require 'sinatra'` with
-   `require 'sinatra/cloudflare_workers'`. Subclass `Sinatra::Base`.
+2. **Keep your Sinatra app exactly as you wrote it.** Classic style
+   (`require 'sinatra'` + top-level `get '/' do ... end`) and modular
+   style (`require 'sinatra/base'` + `class App < Sinatra::Base` +
+   `config.ru` with `run App`) both work as upstream documents.
+   You do **not** swap the `require` line for a Cloudflare-flavoured
+   one — sinatra-homura wires the Workers runtime into the standard
+   Sinatra entry points automatically.
 
 3. **Add `wrangler.toml`** pointing `main` at `build/worker.entrypoint.mjs` and
    declaring the bindings you need (D1 / KV / R2 / AI / Queue).

--- a/docs/TOOLCHAIN_CONTRACT.md
+++ b/docs/TOOLCHAIN_CONTRACT.md
@@ -40,7 +40,7 @@ globals so older smoke bundles and gradual migrations keep working.
 Homura’s production bundle is built with:
 
 - `-I gems/homura-runtime/lib -I lib -I vendor -I build`
-- `-r opal_patches -r cloudflare_workers -r homura_templates -r homura_assets`
+- `-r opal_patches -r homura/runtime -r homura_templates -r homura_assets`
 - Entry: auto-detected from `config.ru`, `app/hello.rb`, then `app/app.rb` (overridable)
 - Output: `build/hello.no-exit.mjs` (overridable)
 
@@ -88,7 +88,9 @@ Use plain `rake` (not `bundle exec rake`) unless `rake` is added to the
 ## 6. Wrangler bindings (reference)
 
 `wrangler.toml` declares D1, KV, R2, AI, Queues, Durable Objects, etc.
-`lib/cloudflare_workers.rb` maps `env.DB` / `env.KV` / … onto
-`env['cloudflare.*']` keys. Changing binding **names** requires coordinated
-updates in Ruby + TOML — out of scope for Phase 15-A but listed here because
-gem consumers will copy the pattern.
+`gems/homura-runtime/lib/homura/runtime.rb` (with the per-binding
+wrappers under `gems/homura-runtime/lib/homura/runtime/*.rb`) maps
+`env.DB` / `env.KV` / … onto `env['cloudflare.*']` keys. Changing
+binding **names** requires coordinated updates in Ruby + TOML — out
+of scope for Phase 15-A but listed here because gem consumers will
+copy the pattern.

--- a/examples/todo-simple/README.ja.md
+++ b/examples/todo-simple/README.ja.md
@@ -25,7 +25,6 @@
 それ以外は Puma で動かすときと同じ Sinatra そのものだ。
 
 ```ruby
-require 'sinatra/cloudflare_workers'
 require 'sinatra'
 
 TODOS = []

--- a/examples/todo-simple/README.md
+++ b/examples/todo-simple/README.md
@@ -25,7 +25,6 @@ This is the example to copy when you want to demonstrate
 It is otherwise the same Sinatra you'd write on Puma:
 
 ```ruby
-require 'sinatra/cloudflare_workers'
 require 'sinatra'
 
 TODOS = []

--- a/gems/homura-runtime/CHANGELOG.md
+++ b/gems/homura-runtime/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.2 (2026-04-30)
+
+- README: replace the leftover `require 'cloudflare_workers'` line and
+  the `gem 'opal-homura', '= 1.8.3.rc1.3'` pin with the canonical
+  `require 'homura/runtime'` and `= 1.8.3.rc1.5` shipped on RubyGems.
+- README support-matrix Opal row updated to `= 1.8.3.rc1.5` to match.
+- No code changes vs. 0.3.1.
+
 ## 0.3.1 (2026-04-29)
 
 - Fix `release-gems.yml` `Resolve gem target` step: now reads

--- a/gems/homura-runtime/README.md
+++ b/gems/homura-runtime/README.md
@@ -5,7 +5,7 @@ Core Ruby + Module Worker glue for [Opal](https://opalrb.com/) on [Cloudflare Wo
 ## What you get
 
 - `require 'opal_patches'` — additive patches for Opal corelib vs real-world gems (Rack, etc.).
-- `require 'cloudflare_workers'` — Rack handler, Cloudflare bindings, multipart, queue, Durable Objects, etc.
+- `require 'homura/runtime'` — Rack handler, Cloudflare bindings, multipart, queue, Durable Objects, etc. Sinatra apps using `sinatra-homura` get this required automatically; explicit consumers (non-Sinatra Rack apps) call it themselves.
 - `runtime/worker_module.mjs` — fetch / scheduled / queue / DO adapters (**no Opal bundle import**).
 - `runtime/worker.mjs` — thin bootstrap (crypto shim → bundle → `worker_module`) for legacy layouts.
 - `runtime/setup-node-crypto.mjs` — `node:crypto` on `globalThis` before the Opal bundle loads.
@@ -14,7 +14,7 @@ Core Ruby + Module Worker glue for [Opal](https://opalrb.com/) on [Cloudflare Wo
 
 ## Quick start (homura monorepo)
 
-1. `Gemfile`: `gem 'homura-runtime', path: 'gems/homura-runtime'` and `gem 'opal-homura', '= 1.8.3.rc1.3', require: 'opal'` (path or exact pin).
+1. `Gemfile`: `gem 'homura-runtime', '~> 0.3'` and `gem 'opal-homura', '= 1.8.3.rc1.5', require: 'opal'` (in the homura monorepo dev workspace, `path: 'gems/homura-runtime'` is also supported).
 2. `bundle exec homura build` — in generated standalone apps, writes `build/hello.no-exit.mjs` plus root-level `build/worker.entrypoint.mjs`; in the monorepo it writes `build/worker.entrypoint.mjs`.
 3. `wrangler.toml`: generated apps use `main = "build/worker.entrypoint.mjs"` and `compatibility_flags = ["nodejs_compat"]`.
 
@@ -25,7 +25,7 @@ Core Ruby + Module Worker glue for [Opal](https://opalrb.com/) on [Cloudflare Wo
 | Ruby       | 3.4.x            |
 | Node       | ≥ 20             |
 | Wrangler   | ^3.99            |
-| Opal       | = 1.8.3.rc1.3    |
+| Opal       | = 1.8.3.rc1.5    |
 
 ## Wrangler config
 

--- a/gems/homura-runtime/lib/homura/runtime/version.rb
+++ b/gems/homura-runtime/lib/homura/runtime/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HomuraRuntime
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end

--- a/gems/sinatra-homura/CHANGELOG.md
+++ b/gems/sinatra-homura/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.1 (2026-04-30)
+
+- README: drop the leftover `require 'sinatra/cloudflare_workers'` snippet
+  (the require path was retired in 0.3.0). The README now shows the two
+  supported user-facing shapes — classic top-level (`require 'sinatra'`)
+  and modular (`require 'sinatra/base'` + `class App < Sinatra::Base` +
+  `run App`) — and explains that neither needs a Cloudflare-flavoured
+  require because the vendored Sinatra entry points auto-load
+  `homura/runtime` and the sinatra-homura extensions at the bottom.
+- No code changes vs. 0.3.0.
+
 ## 0.3.0 (2026-04-29) — BREAKING: cloudflare_workers naming eliminated
 
 Companion release to homura-runtime 0.3.0. All `cloudflare_workers`

--- a/gems/sinatra-homura/README.md
+++ b/gems/sinatra-homura/README.md
@@ -4,17 +4,39 @@ Opal-oriented Sinatra compatibility patches (`sinatra_opal_patches.rb`) and exte
 
 ## Usage
 
+`sinatra-homura` does not require an explicit `require` line beyond the
+canonical Sinatra entry points — adding `gem 'sinatra-homura'` to your
+`Gemfile` is enough. The vendored Sinatra entry points (`sinatra.rb` /
+`sinatra/base.rb`) auto-load the homura adapter at the bottom, in the
+order: `homura/runtime` → Opal/Sinatra patches → `Sinatra::Base` →
+JwtAuth / Scheduled / Queue extensions.
+
+Classic top-level Sinatra (the canonical sinatrarb.com snippet shape):
+
 ```ruby
-require 'sinatra/cloudflare_workers'
-require 'sequel' # etc.
+require 'sinatra'
+
+get '/frank-says' do
+  'Put this in your pipe & smoke it!'
+end
+```
+
+Modular Sinatra (`bundle exec homura new` scaffolds this layout):
+
+```ruby
+require 'sinatra/base'
 
 class App < Sinatra::Base
   register Sinatra::JwtAuth
   # ...
 end
 
-run App # optional if `App` is defined; a fallback registers the Rack handler at exit
+run App
 ```
+
+In neither shape does user code reach for a Cloudflare-flavoured
+require. Everything Workers-specific lives in `homura-runtime` and is
+auto-loaded by sinatra-homura.
 
 ## Scaffolding
 

--- a/gems/sinatra-homura/sinatra-homura.gemspec
+++ b/gems/sinatra-homura/sinatra-homura.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = 'sinatra-homura'
-  spec.version = '0.3.0'
+  spec.version = '0.3.1'
   spec.authors = ['Kazuhiro Homma']
   spec.summary = 'Sinatra + Opal patches and extensions for Cloudflare Workers'
   spec.description = <<~DESC

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -38,11 +38,11 @@ Live demo: https://homura.kazu-san.workers.dev
 ```ruby
 source 'https://rubygems.org'
 
-gem 'opal-homura', '= 1.8.3.rc1.3', require: 'opal'
+gem 'opal-homura',    '= 1.8.3.rc1.5', require: 'opal'
 gem 'rake' # generated apps use this for build/dev/deploy
-gem 'homura-runtime', '= 0.2.9'
-gem 'sinatra-homura', '= 0.2.13'
-gem 'sequel-d1', '= 0.2.7' # optional
+gem 'homura-runtime', '~> 0.3'
+gem 'sinatra-homura', '~> 0.3'
+gem 'sequel-d1',      '~> 0.3' # optional
 ```
 
 ## Minimal flow

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -56,9 +56,30 @@ gem 'sequel-d1', '= 0.2.7' # optional
 
 ## Minimal Sinatra + D1 example
 
+Classic top-level Sinatra (the canonical sinatrarb.com snippet shape):
+
+```ruby
+# app.rb
+require 'sinatra'
+require 'sequel'
+
+get '/users' do
+  db = Sequel.connect(adapter: :d1, d1: env['cloudflare.DB'])
+  content_type 'application/json'
+  db[:users].all.to_json
+end
+```
+
+```ruby
+# config.ru
+require_relative 'app'
+```
+
+Modular Sinatra (the shape `bundle exec homura new` scaffolds):
+
 ```ruby
 # app/app.rb
-require 'sinatra/cloudflare_workers'
+require 'sinatra/base'
 require 'sequel'
 
 class App < Sinatra::Base
@@ -76,6 +97,10 @@ require_relative 'app/app'
 
 run App
 ```
+
+In neither shape does user code reach for a Cloudflare-flavoured
+require: `sinatra-homura` wires the Workers runtime onto the standard
+Sinatra entry points automatically.
 
 ## Key docs
 

--- a/site/views/about.erb
+++ b/site/views/about.erb
@@ -1,12 +1,14 @@
 <h1>About this Sinatra app</h1>
 
-<p>This is <code>app/hello.rb</code>, a real
+<p>This is <code>site/app/app.rb</code>, a real
    <a href="https://github.com/sinatra/sinatra">sinatra/sinatra</a> 4.x
    application running on Cloudflare Workers. Phase 13 moved off the
    old <code>janbiedermann/sinatra</code> fork; we now track upstream
    Sinatra with Opal-specific patches in-repo. The file would run
    unchanged on any Rack server; the Cloudflare adapter lives entirely
-   in <code>lib/cloudflare_workers.rb</code> and does not leak through.</p>
+   in <code>gems/homura-runtime/lib/homura/runtime.rb</code> (with the
+   binding wrappers under <code>gems/homura-runtime/lib/homura/runtime/</code>)
+   and does not leak through.</p>
 
 <h2>Architecture</h2>
 <img src="/architecture.svg" alt="homura architecture diagram" style="width:100%; max-width:800px; margin:1em 0;">

--- a/site/views/docs_migration.erb
+++ b/site/views/docs_migration.erb
@@ -17,7 +17,7 @@
 <h2 id="steps">6 ステップ（推奨順）</h2>
 <ol>
   <li><strong>Gemfile</strong>: <code>opal-homura</code>（<code>require: 'opal'</code>）、<code>homura-runtime</code>、<code>sinatra-homura</code> を追加。D1 を使うなら <code>sequel-d1</code> も追加します。</li>
-  <li><strong>エントリ</strong>: <code>app.rb</code>（またはメイン定義ファイル）の先頭付近に <code># await:</code> マジックコメントを付与（JWT / D1 / fetch など非同期が混ざるファイルは必須。Phase 15-C 教訓）。続けて <code>require 'sinatra/cloudflare_workers'</code>。</li>
+  <li><strong>エントリ</strong>: <code>app.rb</code>（またはメイン定義ファイル）の <code>require 'sinatra'</code>（classic）または <code>require 'sinatra/base'</code>（modular）はそのまま。Cloudflare 専用の <code>require</code> に差し替える必要はありません — <code>sinatra-homura</code> が Sinatra のエントリポイント上で Workers ランタイムを自動配線します。<code>__await__</code> 周りは <code>homura build</code> の auto-await が自動的に挿入するので、<code># await:</code> マジックコメントの手書きは原則不要です。</li>
   <li><strong>ルート</strong>: 既存の <code>get</code> / <code>post</code> を可能な限りそのまま移植。Sinatra の DSL は互換パッチ側で吸収。</li>
   <li><strong>DB</strong>: <code>Sequel.connect(adapter: :d1, d1: env['cloudflare.env'].DB)</code> の形へ。マイグレーションは <code>bundle exec homura db:migrate:compile db/migrations</code> → <code>homura db:migrate:apply</code>（<code>sequel-d1</code> README 参照）。</li>
   <li><strong>ビュー</strong>: <code>bundle exec homura erb:compile --input views --output build/templates.rb --namespace …</code>（プロジェクトの Rake / npm に合わせる）。</li>

--- a/site/views/docs_migration.erb
+++ b/site/views/docs_migration.erb
@@ -19,7 +19,7 @@
   <li><strong>Gemfile</strong>: <code>opal-homura</code>（<code>require: 'opal'</code>）、<code>homura-runtime</code>、<code>sinatra-homura</code> を追加。D1 を使うなら <code>sequel-d1</code> も追加します。</li>
   <li><strong>エントリ</strong>: <code>app.rb</code>（またはメイン定義ファイル）の <code>require 'sinatra'</code>（classic）または <code>require 'sinatra/base'</code>（modular）はそのまま。Cloudflare 専用の <code>require</code> に差し替える必要はありません — <code>sinatra-homura</code> が Sinatra のエントリポイント上で Workers ランタイムを自動配線します。<code>__await__</code> 周りは <code>homura build</code> の auto-await が自動的に挿入するので、<code># await:</code> マジックコメントの手書きは原則不要です。</li>
   <li><strong>ルート</strong>: 既存の <code>get</code> / <code>post</code> を可能な限りそのまま移植。Sinatra の DSL は互換パッチ側で吸収。</li>
-  <li><strong>DB</strong>: <code>Sequel.connect(adapter: :d1, d1: env['cloudflare.env'].DB)</code> の形へ。マイグレーションは <code>bundle exec homura db:migrate:compile db/migrations</code> → <code>homura db:migrate:apply</code>（<code>sequel-d1</code> README 参照）。</li>
+  <li><strong>DB</strong>: <code>Sequel.connect(adapter: :d1, d1: env['cloudflare.DB'])</code> の形へ。マイグレーションは <code>bundle exec homura db:migrate:compile db/migrations</code> → <code>homura db:migrate:apply</code>（<code>sequel-d1</code> README 参照）。</li>
   <li><strong>ビュー</strong>: <code>bundle exec homura erb:compile --input views --output build/templates.rb --namespace …</code>（プロジェクトの Rake / npm に合わせる）。</li>
   <li><strong>Workers 向けビルド</strong>: <code>bundle exec homura build</code>（または <code>--standalone</code>）で <code>build/worker.entrypoint.mjs</code> を生成し、<code>wrangler.toml</code> の <code>main</code> と一致させて <code>wrangler deploy</code>。</li>
 </ol>

--- a/site/views/docs_runtime.erb
+++ b/site/views/docs_runtime.erb
@@ -4,7 +4,7 @@
 <h2 id="role">役割</h2>
 <ul>
   <li><code>require 'opal_patches'</code> — Rack 等との現実的な互換パッチ。</li>
-  <li><code>require 'cloudflare_workers'</code> — Rack ハンドラ、KV / D1 / R2 等のバインディング。</li>
+  <li><code>require 'homura/runtime'</code> — Rack ハンドラ、KV / D1 / R2 / AI / Queue / DO / Cache などの Cloudflare バインディングラッパー（<code>Cloudflare::*</code> 名前空間）。<code>sinatra-homura</code> が Sinatra 経由で自動的にロードするので、ユーザーコードから直接 require することは通常ありません。</li>
   <li><code>homura build</code> — ERB → アセット → Opal → <code>patch-opal-evals.mjs</code> → <code>build/worker.entrypoint.mjs</code> まで一括。</li>
 </ul>
 

--- a/site/views/docs_sinatra.erb
+++ b/site/views/docs_sinatra.erb
@@ -2,12 +2,13 @@
 <p>Sinatra を Opal / Workers 向けに補正するパッチと、JWT・Cron・Queues の拡張を提供します（gem 同梱 README の要約）。</p>
 
 <h2 id="overview">概要</h2>
-<pre><code>require 'sinatra/cloudflare_workers'
+<pre><code>require 'sinatra/base'
 
 class App &lt; Sinatra::Base
   register Sinatra::JwtAuth
   # ...
 end</code></pre>
+<p>classic スタイル（<code>require 'sinatra'</code> + トップレベルの <code>get '/' do ... end</code>）も同じく動きます。<code>sinatra-homura</code> は標準の Sinatra エントリポイント上で Workers ランタイムを自動配線するので、ユーザーコード側で Cloudflare 専用の <code>require</code> は使いません。</p>
 
 <h2 id="register">登録と require</h2>
 <p>アプリクラス内で <code>register</code> し、homura と同様に <code>require 'sequel'</code> 等はルート定義より前に置きます。</p>

--- a/skills/homura-workers-gems/quick-start.md
+++ b/skills/homura-workers-gems/quick-start.md
@@ -15,11 +15,11 @@
 ```ruby
 source 'https://rubygems.org'
 
-gem 'opal-homura', '= 1.8.3.rc1.3', require: 'opal'
+gem 'opal-homura',    '= 1.8.3.rc1.5', require: 'opal'
 gem 'rake' # generated apps use this for build/dev/deploy
-gem 'homura-runtime', '= 0.2.9'
-gem 'sinatra-homura', '= 0.2.13'
-gem 'sequel-d1', '= 0.2.7' # only if D1 / Sequel is needed
+gem 'homura-runtime', '~> 0.3'
+gem 'sinatra-homura', '~> 0.3'
+gem 'sequel-d1',      '~> 0.3' # only if D1 / Sequel is needed
 ```
 
 ## Build / deploy flow
@@ -35,9 +35,11 @@ If `homura build` fails during Opal compile, read `build/opal.stderr.log` first.
 
 ## Minimal runtime snippet
 
+Modular Sinatra (the shape `bundle exec homura new` scaffolds):
+
 ```ruby
 # app/app.rb
-require 'sinatra/cloudflare_workers'
+require 'sinatra/base'
 require 'sequel'
 
 class App < Sinatra::Base
@@ -55,6 +57,31 @@ require_relative 'app/app'
 
 run App
 ```
+
+Classic top-level Sinatra is equally valid — see `examples/sinatra/`,
+`examples/sinatra-with-db/`, and the `examples/classic-top-sinatra/`
+dogfood:
+
+```ruby
+# app.rb
+require 'sinatra'
+require 'sequel'
+
+get '/users' do
+  db = Sequel.connect(adapter: :d1, d1: env['cloudflare.DB'])
+  content_type 'application/json'
+  db[:users].all.to_json
+end
+```
+
+```ruby
+# config.ru
+require_relative 'app'
+```
+
+In neither shape does the user code reach for a Cloudflare-flavoured
+require — `sinatra-homura` wires the Workers runtime onto the standard
+Sinatra entry points automatically.
 
 For the common binding/helper paths above, homura's build step auto-inserts
 `.__await__` under the hood. That includes the common Sequel helper shape


### PR DESCRIPTION
## Summary

After #34 retired the `sinatra/cloudflare_workers` shim and made `sinatra-homura` wire the Workers runtime onto the standard Sinatra entry points automatically, several docs/skills/site views still showed the old recipe (`require 'sinatra/cloudflare_workers'` + force-`Sinatra::Base` + `run App`) and the old `lib/cloudflare_workers*` paths. Anyone following the front-page README, the agent skill, the live `homura.kazu-san.workers.dev` docs, or the architecture references would still see those stale names.

This PR scrubs every remaining user-facing reference to the retired naming while leaving the modular apps that legitimately use `class App < Sinatra::Base` (todo, todo-orm, blog, auth-otp, hotwire-todo, inertia-todo, the canonical site) untouched in their actual code.

## What changed

### Front-page snippets switched to canonical Sinatra
- `README.md` / `README.ja.md` — top hero snippet now uses classic top-level Sinatra (`require 'sinatra'` + bare `get '/users' do`), matches the sinatrarb.com canonical shape #34 standardized on.
- The "How to migrate" step that read _"replace `require 'sinatra'` with `require 'sinatra/cloudflare_workers'`. Subclass `Sinatra::Base`."_ is rewritten to say the opposite: keep your Sinatra app exactly as upstream documents it, both classic and modular shapes work as-is.
- Gem version pins bumped from `~> 0.2` to `~> 0.3` to track the current released line.

### Skill / quick-start
- `skills/homura-workers-gems/quick-start.md`: Gemfile bumped to `~> 0.3` and `opal-homura = 1.8.3.rc1.5`. "Minimal runtime snippet" now shows both the modular and the classic shapes; neither reaches for a Cloudflare-flavoured require.

### Live site (homura.kazu-san.workers.dev)
- `site/public/llms.txt` — agent-facing summary emits canonical classic snippet first, modular shape as a second example, retired `sinatra/cloudflare_workers` line gone.
- `site/views/docs_sinatra.erb` — overview snippet uses `sinatra/base` (with note that classic top-level Sinatra also works).
- `site/views/docs_runtime.erb` — `require 'cloudflare_workers'` line rewritten to `require 'homura/runtime'` with a note that sinatra-homura loads it automatically.
- `site/views/docs_migration.erb` — migration step no longer tells the reader to replace their `require 'sinatra'` line.
- `site/views/about.erb` — `lib/cloudflare_workers.rb` reference updated to the current `gems/homura-runtime/lib/homura/runtime.rb` + `gems/homura-runtime/lib/homura/runtime/*` layout, and the file reference (`app/hello.rb` → `site/app/app.rb`) reflects the post-#35 site/ relocation.

### Internal architecture docs
- `docs/TOOLCHAIN_CONTRACT.md` — Opal compile flags `-r cloudflare_workers` → `-r homura/runtime`; wrangler-bindings section path `lib/cloudflare_workers.rb` → `gems/homura-runtime/lib/homura/runtime.rb`.
- `.claude/skills/opal-workers-gem-adoption/SKILL.md` — self-implemented wrapper row, the cache-IIFE pointer, and the "imitate this" pointer all updated to `gems/homura-runtime/lib/homura/runtime/*.rb`. `lib/homura_markdown.rb` reference updated to `site/lib/` (post-#35).

### todo-simple comparison snippet
`examples/todo-simple/README.md` / `README.ja.md` showed the snippet with both `require 'sinatra/cloudflare_workers'` and `require 'sinatra'` stacked. The dead line is dropped; only `require 'sinatra'` remains, which is what the real `examples/todo-simple/app.rb` ships.

### CI yml comment
`.github/workflows/ci.yml` keeps the historical reference to the `sinatra/cloudflare_workers` strip (it's the reason the `ruby -c (syntax check)` job exists at all) but rewrites the comment so it reads as past tense.

## Verification

- `bundle exec rake build` from `site/` recompiles the canonical app cleanly (`compile-erb: wrote build/homura_templates.rb (22 templates)`, `homura build: ok`) — the rewritten ERBs still parse.
- `wrangler deploy` for the canonical site is intentionally **not** run in this PR; the site redeploy that picks up the new `/llms.txt` and the updated docs ERBs should run after merge.
- `grep -rn 'cloudflare_workers'` post-PR returns only the historical-comment line in `.github/workflows/ci.yml`. All `class App < Sinatra::Base` / `run App` survivors are inside genuinely modular apps and the README sections that compare classic vs modular.

## What is intentionally NOT changed

Modular apps that legitimately use `class App < Sinatra::Base` + `run App`:

- `examples/todo/app/app.rb`, `examples/todo-orm/app/app.rb`
- `examples/blog/app/app.rb`, `examples/auth-otp/app/app.rb`
- `examples/hotwire-todo/app/app.rb`, `examples/inertia-todo/app/app.rb`
- `site/app/app.rb` (the canonical homura site)
- The `class App < Sinatra::Base` snippets inside those READMEs that quote their own real code
- `test/homura_cli_test.rb` / `test/classic_sinatra_smoke.rb` fixtures

Both classic top-level (`require 'sinatra'`) and modular (`require 'sinatra/base'` + `class App < Sinatra::Base`) Sinatra styles are fully supported on homura today; this PR is purely about the docs catching up to that reality.