### PR TITLE
site/Gemfile.lock: bump path-resolved homura-runtime + sinatra-homura

### DIFF
--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: gems/homura-runtime
   specs:
-    homura-runtime (0.3.1)
+    homura-runtime (0.3.2)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
 
@@ -17,7 +17,7 @@ PATH
 PATH
   remote: gems/sinatra-homura
   specs:
-    sinatra-homura (0.3.0)
+    sinatra-homura (0.3.1)
       homura-runtime (~> 0.3)
       opal-homura (= 1.8.3.rc1.5)
 


### PR DESCRIPTION
## Summary

Side effect of the README-only patch releases shipped from #40:

- homura-runtime 0.3.1 → 0.3.2
- sinatra-homura 0.3.0 → 0.3.1

`site/Gemfile` uses `path:` against `../gems/{homura-runtime,sinatra-homura}`, so `bundle install` inside `site/` regenerates the lockfile to match the versions currently checked in there. The worker bundle itself is unchanged (no code diff in those gems vs. their previous versions), but tracking the lockfile bump keeps `git status` clean and makes the dev-mode resolution reproducible.

## Test plan

- `cd site && bundle install` is idempotent on this lockfile against the current `gems/{homura-runtime,sinatra-homura}` versions.
- The canonical site is already deployed at https://homura.kazu-san.workers.dev — no behaviour change expected from this PR; it is purely metadata.