### PR TITLE
Release homura-runtime 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: gems/homura-runtime
   specs:
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
 

--- a/gems/homura-runtime/CHANGELOG.md
+++ b/gems/homura-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.6 (2026-05-03)
+
+- Release the no-await-surface examples/docs baseline: public Rack,
+  Sinatra, D1, Email, and Durable Object examples should stay sync-shaped
+  and avoid exposing Opal/Workers await internals in user-written Ruby.
+- No runtime code changes vs. 0.3.5.
+
 ## 0.3.5 (2026-05-03)
 
 - Add Ruby-shaped Cloudflare binding helpers for HTTP, scheduled, queue,

--- a/gems/homura-runtime/lib/homura/runtime/version.rb
+++ b/gems/homura-runtime/lib/homura/runtime/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HomuraRuntime
-  VERSION = '0.3.5'
+  VERSION = '0.3.6'
 end


### PR DESCRIPTION
## Why

Cut a published gem version after removing await internals from public example/doc surfaces, so downstream examples can pin a released gem for this baseline.

## What

- Bump homura-runtime to 0.3.6.
- Add changelog entry noting this is a no-runtime-code release over 0.3.5 for the no-await-surface examples/docs baseline.

## Verification

- `mise exec -- ruby -e 'load "gems/homura-runtime/lib/homura/runtime/version.rb"; abort HomuraRuntime::VERSION unless HomuraRuntime::VERSION == "0.3.6"; puts HomuraRuntime::VERSION'`
- `mise exec -- gem build homura-runtime.gemspec --output /tmp/homura-runtime-0.3.6.gem`