### PR TITLE
Use homura-runtime 0.3.6 in examples

### DIFF
--- a/examples/auth-otp/Gemfile
+++ b/examples/auth-otp/Gemfile
@@ -5,7 +5,7 @@ ruby '>= 3.4.0'
 
 gem 'rake'
 gem 'opal-homura', '= 1.8.3.rc1.5', require: 'opal'
-gem 'homura-runtime', '= 0.3.5'
+gem 'homura-runtime', '= 0.3.6'
 gem 'sinatra-homura', '= 0.3.2'
 gem 'sequel-d1', '= 0.3.1'
 gem 'sequel', '~> 5.0'

--- a/examples/auth-otp/Gemfile.lock
+++ b/examples/auth-otp/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     concurrent-ruby (1.3.6)
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
     logger (1.7.0)
@@ -42,7 +42,7 @@ PLATFORMS
   arm64-darwin-25
 
 DEPENDENCIES
-  homura-runtime (= 0.3.5)
+  homura-runtime (= 0.3.6)
   opal-homura (= 1.8.3.rc1.5)
   playwright-ruby-client (~> 1.50)
   rake

--- a/examples/blog/Gemfile
+++ b/examples/blog/Gemfile
@@ -5,7 +5,7 @@ ruby '>= 3.4.0'
 
 gem 'rake'
 gem 'opal-homura', '= 1.8.3.rc1.5', require: 'opal'
-gem 'homura-runtime', '= 0.3.5'
+gem 'homura-runtime', '= 0.3.6'
 gem 'sinatra-homura', '= 0.3.2'
 gem 'sequel-d1', '= 0.3.1'
 gem 'sequel', '~> 5.0'

--- a/examples/blog/Gemfile.lock
+++ b/examples/blog/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
     opal-homura (1.8.3.rc1.5)
@@ -32,7 +32,7 @@ PLATFORMS
   arm64-darwin-25
 
 DEPENDENCIES
-  homura-runtime (= 0.3.5)
+  homura-runtime (= 0.3.6)
   opal-homura (= 1.8.3.rc1.5)
   rake
   sequel (~> 5.0)

--- a/examples/classic-top-sinatra/Gemfile
+++ b/examples/classic-top-sinatra/Gemfile
@@ -4,5 +4,5 @@ ruby '>= 3.4.0'
 
 gem 'rake' # used by Rakefile (build / dev / deploy entry points)
 gem 'opal-homura', '= 1.8.3.rc1.5', require: 'opal'
-gem 'homura-runtime', '= 0.3.5'
+gem 'homura-runtime', '= 0.3.6'
 gem 'sinatra-homura', '= 0.3.2'

--- a/examples/classic-top-sinatra/Gemfile.lock
+++ b/examples/classic-top-sinatra/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     ast (2.4.3)
     base64 (0.3.0)
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
     opal-homura (1.8.3.rc1.5)
@@ -24,7 +24,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  homura-runtime (= 0.3.5)
+  homura-runtime (= 0.3.6)
   opal-homura (= 1.8.3.rc1.5)
   rake
   sinatra-homura (= 0.3.2)

--- a/examples/hotwire-todo/Gemfile
+++ b/examples/hotwire-todo/Gemfile
@@ -5,7 +5,7 @@ ruby '>= 3.4.0'
 
 gem 'rake'
 gem 'opal-homura', '= 1.8.3.rc1.5', require: 'opal'
-gem 'homura-runtime', '= 0.3.5'
+gem 'homura-runtime', '= 0.3.6'
 gem 'sinatra-homura', '= 0.3.2'
 
 # D1 / Sequel migrations (compile-time only). The Worker itself talks to D1

--- a/examples/hotwire-todo/Gemfile.lock
+++ b/examples/hotwire-todo/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
     opal-homura (1.8.3.rc1.5)
@@ -32,7 +32,7 @@ PLATFORMS
   arm64-darwin-25
 
 DEPENDENCIES
-  homura-runtime (= 0.3.5)
+  homura-runtime (= 0.3.6)
   opal-homura (= 1.8.3.rc1.5)
   rake
   sequel (~> 5.0)

--- a/examples/inertia-todo/Gemfile
+++ b/examples/inertia-todo/Gemfile
@@ -7,7 +7,7 @@ ruby '>= 3.4.0'
 # CLAUDE.md, this Gemfile must NOT link any unreleased local gem;
 # new versions get `gem build` + `gem push`-ed first.
 gem 'opal-homura', '= 1.8.3.rc1.5', require: 'opal'
-gem 'homura-runtime', '= 0.3.5'
+gem 'homura-runtime', '= 0.3.6'
 gem 'sinatra-homura', '= 0.3.2'
 gem 'sinatra-inertia', '= 0.1.4'
 gem 'sequel-d1', '= 0.3.1'

--- a/examples/inertia-todo/Gemfile.lock
+++ b/examples/inertia-todo/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
     logger (1.7.0)
@@ -71,7 +71,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  homura-runtime (= 0.3.5)
+  homura-runtime (= 0.3.6)
   opal-homura (= 1.8.3.rc1.5)
   rake
   sequel (~> 5.0)

--- a/examples/rack/Gemfile
+++ b/examples/rack/Gemfile
@@ -5,4 +5,4 @@ ruby '>= 3.4.0'
 
 gem 'rake'
 gem 'opal-homura', '= 1.8.3.rc1.5', require: 'opal'
-gem 'homura-runtime', '= 0.3.5'
+gem 'homura-runtime', '= 0.3.6'

--- a/examples/rack/Gemfile.lock
+++ b/examples/rack/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     ast (2.4.3)
     base64 (0.3.0)
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
     opal-homura (1.8.3.rc1.5)
@@ -21,7 +21,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  homura-runtime (= 0.3.5)
+  homura-runtime (= 0.3.6)
   opal-homura (= 1.8.3.rc1.5)
   rake
 

--- a/examples/sinatra-with-db/Gemfile
+++ b/examples/sinatra-with-db/Gemfile
@@ -6,6 +6,6 @@ ruby '>= 3.4.0'
 
 gem 'rake' # used by Rakefile (build / dev / deploy / db:migrate:* entry points)
 gem 'opal-homura', '= 1.8.3.rc1.5', require: 'opal'
-gem 'homura-runtime', '= 0.3.5'
+gem 'homura-runtime', '= 0.3.6'
 gem 'sinatra-homura', '= 0.3.2'
 gem 'sequel-d1', '= 0.3.1'

--- a/examples/sinatra-with-db/Gemfile.lock
+++ b/examples/sinatra-with-db/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
     opal-homura (1.8.3.rc1.5)
@@ -50,7 +50,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  homura-runtime (= 0.3.5)
+  homura-runtime (= 0.3.6)
   opal-homura (= 1.8.3.rc1.5)
   rake
   sequel-d1 (= 0.3.1)

--- a/examples/sinatra-with-email/Gemfile
+++ b/examples/sinatra-with-email/Gemfile
@@ -5,5 +5,5 @@ ruby '>= 3.4.0'
 
 gem 'rake' # used by Rakefile (build / dev / deploy entry points)
 gem 'opal-homura', '= 1.8.3.rc1.5', require: 'opal'
-gem 'homura-runtime', '= 0.3.5'
+gem 'homura-runtime', '= 0.3.6'
 gem 'sinatra-homura', '= 0.3.2'

--- a/examples/sinatra-with-email/Gemfile.lock
+++ b/examples/sinatra-with-email/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     ast (2.4.3)
     base64 (0.3.0)
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
     opal-homura (1.8.3.rc1.5)
@@ -23,7 +23,7 @@ PLATFORMS
   arm64-darwin-25
 
 DEPENDENCIES
-  homura-runtime (= 0.3.5)
+  homura-runtime (= 0.3.6)
   opal-homura (= 1.8.3.rc1.5)
   rake
   sinatra-homura (= 0.3.2)

--- a/examples/sinatra/Gemfile
+++ b/examples/sinatra/Gemfile
@@ -5,5 +5,5 @@ ruby '>= 3.4.0'
 
 gem 'rake' # used by Rakefile (build / dev / deploy entry points)
 gem 'opal-homura', '= 1.8.3.rc1.5', require: 'opal'
-gem 'homura-runtime', '= 0.3.5'
+gem 'homura-runtime', '= 0.3.6'
 gem 'sinatra-homura', '= 0.3.2'

--- a/examples/sinatra/Gemfile.lock
+++ b/examples/sinatra/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     ast (2.4.3)
     base64 (0.3.0)
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
     opal-homura (1.8.3.rc1.5)
@@ -24,7 +24,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  homura-runtime (= 0.3.5)
+  homura-runtime (= 0.3.6)
   opal-homura (= 1.8.3.rc1.5)
   rake
   sinatra-homura (= 0.3.2)

--- a/examples/todo-orm/Gemfile
+++ b/examples/todo-orm/Gemfile
@@ -5,7 +5,7 @@ ruby '>= 3.4.0'
 
 gem 'rake'
 gem 'opal-homura', '= 1.8.3.rc1.5', require: 'opal'
-gem 'homura-runtime', '= 0.3.5'
+gem 'homura-runtime', '= 0.3.6'
 gem 'sinatra-homura', '= 0.3.2'
 gem 'sequel-d1', '= 0.3.1'
 gem 'sequel', '~> 5.0'

--- a/examples/todo-orm/Gemfile.lock
+++ b/examples/todo-orm/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
     opal-homura (1.8.3.rc1.5)
@@ -50,7 +50,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  homura-runtime (= 0.3.5)
+  homura-runtime (= 0.3.6)
   opal-homura (= 1.8.3.rc1.5)
   rake
   sequel (~> 5.0)

--- a/examples/todo-simple/Gemfile
+++ b/examples/todo-simple/Gemfile
@@ -6,5 +6,5 @@ ruby '>= 3.4.0'
 
 gem 'rake'
 gem 'opal-homura',    '= 1.8.3.rc1.5', require: 'opal'
-gem 'homura-runtime', '= 0.3.5'
+gem 'homura-runtime', '= 0.3.6'
 gem 'sinatra-homura', '= 0.3.2'

--- a/examples/todo-simple/Gemfile.lock
+++ b/examples/todo-simple/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     ast (2.4.3)
     base64 (0.3.0)
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
     opal-homura (1.8.3.rc1.5)
@@ -24,7 +24,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  homura-runtime (= 0.3.5)
+  homura-runtime (= 0.3.6)
   opal-homura (= 1.8.3.rc1.5)
   rake
   sinatra-homura (= 0.3.2)

--- a/examples/todo/Gemfile
+++ b/examples/todo/Gemfile
@@ -5,7 +5,7 @@ ruby '>= 3.4.0'
 
 gem 'rake'
 gem 'opal-homura', '= 1.8.3.rc1.5', require: 'opal'
-gem 'homura-runtime', '= 0.3.5'
+gem 'homura-runtime', '= 0.3.6'
 gem 'sinatra-homura', '= 0.3.2'
 gem 'sequel-d1', '= 0.3.1'
 gem 'sequel', '~> 5.0'

--- a/examples/todo/Gemfile.lock
+++ b/examples/todo/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.1.2)
-    homura-runtime (0.3.5)
+    homura-runtime (0.3.6)
       opal-homura (= 1.8.3.rc1.5)
       parser (~> 3.3)
     opal-homura (1.8.3.rc1.5)
@@ -32,7 +32,7 @@ PLATFORMS
   arm64-darwin-25
 
 DEPENDENCIES
-  homura-runtime (= 0.3.5)
+  homura-runtime (= 0.3.6)
   opal-homura (= 1.8.3.rc1.5)
   rake
   sequel (~> 5.0)


### PR DESCRIPTION
## Why

homura-runtime 0.3.6 is now published. Examples should use the released gem rather than the previous 0.3.5 pin.

## What

- Update every example Gemfile to `homura-runtime`, `= 0.3.6`.
- Update every example Gemfile.lock from RubyGems.

## Verification

- RubyGems API shows homura-runtime 0.3.6.
- `mise exec -- gem install homura-runtime -v 0.3.6 --no-document --install-dir /tmp/homura-runtime-036-check`
- `bundle update homura-runtime` in all examples.
- `mise exec -- bundle exec rake build` in all 12 examples.
- `wrangler dev --local` HTTP checks:
  - sinatra-with-db `GET /` 200
  - sinatra-with-db `GET /users` 200 `{"users":[]}`
  - todo-orm `GET /` 200
  - auth-otp `GET /` 200
  - auth-otp `GET /login` 200